### PR TITLE
Implement CertStore CAS and PO index with determinism test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ coverage/
 *.gcov
 *.gcda
 *.gcno
+
+# Allow source certstore library
+!libs/certstore/
+!libs/certstore/**

--- a/include/sappp/certstore.hpp
+++ b/include/sappp/certstore.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+/**
+ * @file certstore.hpp
+ * @brief Content-addressed cert storage and PO index
+ */
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace sappp {
+
+class CertStore {
+public:
+    explicit CertStore(std::filesystem::path base_path);
+
+    std::string put(const nlohmann::json& cert);
+    std::optional<nlohmann::json> get(const std::string& hash) const;
+    void bind_po(const std::string& po_id, const std::string& cert_hash) const;
+
+private:
+    std::filesystem::path base_path_;
+
+    std::filesystem::path object_path_for_hash(const std::string& hash) const;
+    std::filesystem::path index_path_for_po(const std::string& po_id) const;
+};
+
+} // namespace sappp

--- a/libs/certstore/CMakeLists.txt
+++ b/libs/certstore/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(sappp_certstore
+    certstore.cpp
+)
+
+target_include_directories(sappp_certstore PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(sappp_certstore PUBLIC
+    sappp_canonical
+    nlohmann_json::nlohmann_json
+)

--- a/libs/certstore/certstore.cpp
+++ b/libs/certstore/certstore.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file certstore.cpp
+ * @brief Content-addressed cert storage and PO index implementation
+ */
+
+#include "sappp/certstore.hpp"
+
+#include "sappp/canonical_json.hpp"
+
+#include <fstream>
+#include <stdexcept>
+
+namespace sappp {
+
+namespace {
+
+std::string hash_prefix_dir(const std::string& hash) {
+    constexpr std::string_view prefix = "sha256:";
+    if (hash.rfind(prefix, 0) == 0 && hash.size() >= prefix.size() + 2) {
+        return hash.substr(prefix.size(), 2);
+    }
+    if (hash.size() >= 2) {
+        return hash.substr(0, 2);
+    }
+    return hash;
+}
+
+nlohmann::json load_json_file(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input) {
+        throw std::runtime_error("Failed to open file: " + path.string());
+    }
+    return nlohmann::json::parse(input);
+}
+
+void write_text_file(const std::filesystem::path& path, const std::string& content) {
+    std::ofstream output(path);
+    if (!output) {
+        throw std::runtime_error("Failed to open file for writing: " + path.string());
+    }
+    output << content;
+    if (!output.good()) {
+        throw std::runtime_error("Failed to write file: " + path.string());
+    }
+}
+
+} // namespace
+
+CertStore::CertStore(std::filesystem::path base_path)
+    : base_path_(std::move(base_path)) {}
+
+std::string CertStore::put(const nlohmann::json& cert) {
+    const std::string hash = canonical::hash_canonical(cert);
+    const std::filesystem::path object_path = object_path_for_hash(hash);
+    std::filesystem::create_directories(object_path.parent_path());
+    const std::string canonical = canonical::canonicalize(cert);
+    write_text_file(object_path, canonical);
+    return hash;
+}
+
+std::optional<nlohmann::json> CertStore::get(const std::string& hash) const {
+    const std::filesystem::path object_path = object_path_for_hash(hash);
+    if (!std::filesystem::exists(object_path)) {
+        return std::nullopt;
+    }
+    return load_json_file(object_path);
+}
+
+void CertStore::bind_po(const std::string& po_id, const std::string& cert_hash) const {
+    const std::filesystem::path index_path = index_path_for_po(po_id);
+    std::filesystem::create_directories(index_path.parent_path());
+
+    nlohmann::json index = {
+        {"schema_version", "cert_index.v1"},
+        {"po_id", po_id},
+        {"root", cert_hash}
+    };
+
+    const std::string canonical = canonical::canonicalize(index);
+    write_text_file(index_path, canonical);
+}
+
+std::filesystem::path CertStore::object_path_for_hash(const std::string& hash) const {
+    const std::string prefix = hash_prefix_dir(hash);
+    return base_path_ / "objects" / prefix / (hash + ".json");
+}
+
+std::filesystem::path CertStore::index_path_for_po(const std::string& po_id) const {
+    return base_path_ / "index" / (po_id + ".json");
+}
+
+} // namespace sappp

--- a/tests/determinism/CMakeLists.txt
+++ b/tests/determinism/CMakeLists.txt
@@ -2,11 +2,13 @@ add_executable(test_determinism
     test_sha256.cpp
     test_path.cpp
     test_canonical_json.cpp
+    test_certstore.cpp
 )
 
 target_link_libraries(test_determinism PRIVATE
     sappp_common
     sappp_canonical
+    sappp_certstore
     GTest::gtest_main
 )
 

--- a/tests/determinism/test_certstore.cpp
+++ b/tests/determinism/test_certstore.cpp
@@ -1,0 +1,56 @@
+#include "sappp/certstore.hpp"
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+
+namespace {
+
+std::filesystem::path make_temp_dir() {
+    auto now = std::chrono::system_clock::now().time_since_epoch().count();
+    std::filesystem::path base = std::filesystem::temp_directory_path() /
+        ("sappp_certstore_test_" + std::to_string(now));
+    std::filesystem::create_directories(base);
+    return base;
+}
+
+} // namespace
+
+TEST(CertStoreDeterminism, PutIsDeterministicForEquivalentJson) {
+    std::filesystem::path base = make_temp_dir();
+    sappp::CertStore store(base);
+
+    nlohmann::json cert_a = {
+        {"b", 2},
+        {"a", 1}
+    };
+    nlohmann::json cert_b = {
+        {"a", 1},
+        {"b", 2}
+    };
+
+    std::string hash_a = store.put(cert_a);
+    std::string hash_b = store.put(cert_b);
+
+    EXPECT_EQ(hash_a, hash_b);
+
+    auto loaded = store.get(hash_a);
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded.value(), cert_a);
+
+    const std::string po_id = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    store.bind_po(po_id, hash_a);
+
+    std::filesystem::path index_path = base / "index" / (po_id + ".json");
+    ASSERT_TRUE(std::filesystem::exists(index_path));
+
+    nlohmann::json index = nlohmann::json::parse(std::ifstream(index_path));
+    EXPECT_EQ(index.at("schema_version"), "cert_index.v1");
+    EXPECT_EQ(index.at("po_id"), po_id);
+    EXPECT_EQ(index.at("root"), hash_a);
+
+    std::filesystem::remove_all(base);
+}


### PR DESCRIPTION
### Motivation
- Provide content-addressed storage for PO-level certificates using canonical JSON hashing so identical logical JSON yields the same hash. 
- Persist certificate objects and a PO -> root index to allow retrieval and deterministic indexing of proofs.

### Description
- Add `CertStore` API (`put`, `get`, `bind_po`) in `include/sappp/certstore.hpp` and implement it in `libs/certstore/certstore.cpp` using `sappp::canonical::hash_canonical()` for hashing. 
- Store objects as `<base>/objects/<first2chars>/<full_hash>.json` and indexes as `<base>/index/<po_id>.json` and write files in canonicalized form. 
- Add library target `sappp_certstore` via `libs/certstore/CMakeLists.txt` and wire it into the determinism test target. 
- Add determinism test `tests/determinism/test_certstore.cpp` and update `tests/determinism/CMakeLists.txt`, and allow the new source tree in `.gitignore`.

### Testing
- Added automated test `tests/determinism/test_certstore.cpp` which checks `put` determinism, `get` correctness, and `bind_po` index writing. 
- The test is compiled as part of the `test_determinism` target via `tests/determinism/CMakeLists.txt`. 
- No automated tests were executed as part of this change (tests added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b5a42a7d8832dbd9e333d058588e9)