### PR TITLE
Enable CTest and register GoogleTest suites with labeled discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_subdirectory(tools/sappp)
 
 # Tests
 if(SAPPP_BUILD_TESTS)
+    include(CTest)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 # Find or fetch GoogleTest
 include(FetchContent)
 FetchContent_Declare(
@@ -8,6 +6,17 @@ FetchContent_Declare(
     GIT_TAG v1.14.0
 )
 FetchContent_MakeAvailable(googletest)
+
+include(GoogleTest)
+set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
+
+function(sappp_register_gtest target label)
+    gtest_discover_tests(${target}
+        DISCOVERY_MODE PRE_TEST
+        TEST_PREFIX "${label}."
+        PROPERTIES LABELS ${label}
+    )
+endfunction()
 
 # Schema validation tests
 add_subdirectory(schemas)

--- a/tests/build_capture/CMakeLists.txt
+++ b/tests/build_capture/CMakeLists.txt
@@ -13,5 +13,4 @@ target_compile_definitions(test_build_capture PRIVATE
     SAPPP_SCHEMA_DIR=\"${CMAKE_SOURCE_DIR}/schemas\"
 )
 
-include(GoogleTest)
-gtest_discover_tests(test_build_capture)
+sappp_register_gtest(test_build_capture build_capture)

--- a/tests/determinism/CMakeLists.txt
+++ b/tests/determinism/CMakeLists.txt
@@ -16,5 +16,4 @@ target_compile_definitions(test_determinism PRIVATE
     SAPPP_SCHEMA_DIR=\"${CMAKE_SOURCE_DIR}/schemas\"
 )
 
-include(GoogleTest)
-gtest_discover_tests(test_determinism)
+sappp_register_gtest(test_determinism determinism)

--- a/tests/frontend_clang/CMakeLists.txt
+++ b/tests/frontend_clang/CMakeLists.txt
@@ -14,5 +14,4 @@ target_compile_definitions(test_frontend_clang PRIVATE
     SAPPP_CXX_COMPILER="${CMAKE_CXX_COMPILER}"
 )
 
-include(GoogleTest)
-gtest_discover_tests(test_frontend_clang)
+sappp_register_gtest(test_frontend_clang frontend_clang)

--- a/tests/schemas/CMakeLists.txt
+++ b/tests/schemas/CMakeLists.txt
@@ -11,5 +11,4 @@ target_compile_definitions(test_schema_validate PRIVATE
     SAPPP_SCHEMA_DIR=\"${CMAKE_SOURCE_DIR}/schemas\"
 )
 
-include(GoogleTest)
-gtest_discover_tests(test_schema_validate)
+sappp_register_gtest(test_schema_validate schemas)

--- a/tests/validator/CMakeLists.txt
+++ b/tests/validator/CMakeLists.txt
@@ -15,5 +15,4 @@ target_compile_definitions(test_validator PRIVATE
     SAPPP_SCHEMA_DIR="${CMAKE_SOURCE_DIR}/schemas"
 )
 
-include(GoogleTest)
-gtest_discover_tests(test_validator)
+sappp_register_gtest(test_validator validator)


### PR DESCRIPTION
### Motivation
- Fix Issue #21 by ensuring CTest is initialized and that all test executables are discovered so `ctest --test-dir build` does not report "No tests were found!!!".
- Allow runtime filtering such as `ctest -R determinism` by adding stable, labeled test prefixes during GoogleTest discovery.
- Centralize gtest discovery to make test registration consistent across test subdirectories.

### Description
- Add `include(CTest)` to the root `CMakeLists.txt` so CTest integration is configured whenever `SAPPP_BUILD_TESTS` is enabled. 
- Centralize GoogleTest discovery in `tests/CMakeLists.txt` by adding `include(GoogleTest)`, setting discovery mode, and introducing `sappp_register_gtest(target label)` which calls `gtest_discover_tests` with a `TEST_PREFIX` and `LABELS` property.
- Replace per-suite `gtest_discover_tests` calls with `sappp_register_gtest(...)` in all test suite CMake files to consistently prefix and label discovered tests (updated files include `tests/CMakeLists.txt`, `tests/determinism/CMakeLists.txt`, `tests/build_capture/CMakeLists.txt`, `tests/schemas/CMakeLists.txt`, `tests/validator/CMakeLists.txt`, and `tests/frontend_clang/CMakeLists.txt`).

### Testing
- Configured the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF` and configuration completed successfully.
- Built the project with `cmake --build build --parallel` and the build completed successfully (test binaries were produced in `build/bin`).
- Ran `ctest --test-dir build --output-on-failure` which executed all tests (30 tests passed, 0 failed) and ran `ctest --test-dir build -R determinism --output-on-failure` which successfully filtered and executed the determinism suite (24 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b95ebffd8832d83363d8695fc90e0)