### PR TITLE
Add `sappp explain` command and report explain library for UNKNOWN ledgers

### DIFF
--- a/include/sappp/report/explain.hpp
+++ b/include/sappp/report/explain.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "sappp/common.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace sappp::report {
+
+enum class ExplainFormat { kText, kJson };
+
+struct ExplainOptions
+{
+    std::filesystem::path unknown_path;
+    std::optional<std::filesystem::path> validated_path;
+    std::optional<std::string> po_id;
+    std::optional<std::string> unknown_id;
+    std::optional<std::filesystem::path> output_path;
+    std::string schema_dir;
+    ExplainFormat format;
+};
+
+struct ExplainOutput
+{
+    ExplainFormat format;
+    std::size_t unknown_count;
+    std::string summary;
+    nlohmann::json json;
+    std::vector<std::string> text;
+};
+
+[[nodiscard]] sappp::Result<ExplainOutput> explain_unknowns(const ExplainOptions& options);
+
+[[nodiscard]] sappp::VoidResult write_explain_output(const ExplainOptions& options,
+                                                     const ExplainOutput& output);
+
+}  // namespace sappp::report

--- a/libs/report/CMakeLists.txt
+++ b/libs/report/CMakeLists.txt
@@ -1,3 +1,14 @@
-# Placeholder for report library
-add_library(sappp_report INTERFACE)
-target_include_directories(sappp_report INTERFACE ${CMAKE_SOURCE_DIR}/include)
+# Report library
+add_library(sappp_report
+    explain.cpp
+)
+
+sappp_target_strict_warnings(sappp_report)
+
+target_include_directories(sappp_report PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+target_link_libraries(sappp_report PUBLIC
+    sappp_common
+    sappp_canonical
+    nlohmann_json::nlohmann_json
+)

--- a/libs/report/explain.cpp
+++ b/libs/report/explain.cpp
@@ -1,0 +1,333 @@
+#include "sappp/report/explain.hpp"
+
+#include "sappp/canonical_json.hpp"
+#include "sappp/common.hpp"
+#include "sappp/schema_validate.hpp"
+#include "sappp/version.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <optional>
+#include <print>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sappp::report {
+
+namespace {
+
+[[nodiscard]] sappp::Result<nlohmann::json> read_json_file(const std::filesystem::path& path)
+{
+    std::ifstream in(path);
+    if (!in) {
+        return std::unexpected(
+            sappp::Error::make("IOError", "Failed to open JSON file: " + path.string()));
+    }
+    nlohmann::json payload;
+    try {
+        in >> payload;
+    } catch (const std::exception& ex) {
+        return std::unexpected(
+            sappp::Error::make("ParseError",
+                               "Failed to parse JSON file: " + path.string() + ": " + ex.what()));
+    }
+    return payload;
+}
+
+[[nodiscard]] sappp::Result<nlohmann::json> load_and_validate_unknown(const ExplainOptions& options)
+{
+    auto unknown_payload = read_json_file(options.unknown_path);
+    if (!unknown_payload) {
+        return std::unexpected(unknown_payload.error());
+    }
+    const std::filesystem::path schema_path =
+        std::filesystem::path(options.schema_dir) / "unknown.v1.schema.json";
+    if (auto validation = sappp::common::validate_json(*unknown_payload, schema_path.string());
+        !validation) {
+        return std::unexpected(sappp::Error::make("SchemaInvalid",
+                                                  std::string("unknown schema validation failed: ")
+                                                      + validation.error().message));
+    }
+    return *unknown_payload;
+}
+
+[[nodiscard]] sappp::Result<std::optional<nlohmann::json>>
+load_validated_results(const ExplainOptions& options)
+{
+    if (!options.validated_path) {
+        return std::optional<nlohmann::json>{};
+    }
+    auto validated_payload = read_json_file(*options.validated_path);
+    if (!validated_payload) {
+        return std::unexpected(validated_payload.error());
+    }
+    const std::filesystem::path schema_path =
+        std::filesystem::path(options.schema_dir) / "validated_results.v1.schema.json";
+    if (auto validation = sappp::common::validate_json(*validated_payload, schema_path.string());
+        !validation) {
+        return std::unexpected(
+            sappp::Error::make("SchemaInvalid",
+                               std::string("validated_results schema validation failed: ")
+                                   + validation.error().message));
+    }
+    return std::optional<nlohmann::json>{*validated_payload};
+}
+
+[[nodiscard]] std::string current_time_utc()
+{
+    const auto now = std::chrono::system_clock::now();
+    return std::format("{:%Y-%m-%dT%H:%M:%SZ}", std::chrono::floor<std::chrono::seconds>(now));
+}
+
+[[nodiscard]] std::optional<nlohmann::json>
+find_result_for_po(const nlohmann::json& validated_results, std::string_view po_id)
+{
+    if (!validated_results.contains("results")) {
+        return std::nullopt;
+    }
+    for (const auto& result : validated_results.at("results")) {
+        if (result.value("po_id", "") == po_id) {
+            return result;
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] bool matches_filters(const nlohmann::json& unknown,
+                                   const ExplainOptions& options,
+                                   const std::optional<nlohmann::json>& validated_results)
+{
+    const std::string po_id = unknown.value("po_id", "");
+    if (options.po_id && *options.po_id != po_id) {
+        return false;
+    }
+    if (options.unknown_id && *options.unknown_id != unknown.value("unknown_stable_id", "")) {
+        return false;
+    }
+    if (validated_results) {
+        auto result = find_result_for_po(*validated_results, po_id);
+        if (!result || result->value("category", "") != "UNKNOWN") {
+            return false;
+        }
+    }
+    return true;
+}
+
+void append_missing_lemma(std::vector<std::string>& lines, const nlohmann::json& unknown)
+{
+    if (const auto missing_lemma = unknown.find("missing_lemma"); missing_lemma != unknown.end()) {
+        lines.emplace_back(std::string("  missing_lemma: ") + missing_lemma->value("pretty", ""));
+        if (missing_lemma->contains("notes")) {
+            lines.emplace_back(std::string("  notes: ") + missing_lemma->value("notes", ""));
+        }
+        if (missing_lemma->contains("symbols")) {
+            std::string symbols = "  symbols: ";
+            const auto& list = missing_lemma->at("symbols");
+            for (auto [i, item] : std::views::enumerate(list)) {
+                if (i != 0) {
+                    symbols += ", ";
+                }
+                symbols += item.get<std::string>();
+            }
+            lines.emplace_back(std::move(symbols));
+        }
+    }
+}
+
+void append_refinement_plan(std::vector<std::string>& lines, const nlohmann::json& unknown)
+{
+    if (const auto refinement_plan = unknown.find("refinement_plan");
+        refinement_plan != unknown.end()) {
+        lines.emplace_back(std::string("  refinement: ") + refinement_plan->value("message", ""));
+        if (refinement_plan->contains("actions")) {
+            for (const auto& action : refinement_plan->at("actions")) {
+                lines.emplace_back(std::string("    - ") + action.value("action", ""));
+            }
+        }
+    }
+}
+
+void append_depends_on(std::vector<std::string>& lines, const nlohmann::json& unknown)
+{
+    if (const auto depends_on = unknown.find("depends_on"); depends_on != unknown.end()) {
+        if (depends_on->contains("contracts")) {
+            std::string contracts = "  contracts: ";
+            const auto& list = depends_on->at("contracts");
+            for (auto [i, item] : std::views::enumerate(list)) {
+                if (i != 0) {
+                    contracts += ", ";
+                }
+                contracts += item.get<std::string>();
+            }
+            lines.emplace_back(std::move(contracts));
+        }
+        if (depends_on->contains("semantics_deviations")) {
+            std::string deviations = "  semantics_deviations: ";
+            const auto& list = depends_on->at("semantics_deviations");
+            for (auto [i, item] : std::views::enumerate(list)) {
+                if (i != 0) {
+                    deviations += ", ";
+                }
+                deviations += item.get<std::string>();
+            }
+            lines.emplace_back(std::move(deviations));
+        }
+    }
+}
+
+void append_validator_status(std::vector<std::string>& lines,
+                             const nlohmann::json& unknown,
+                             const std::optional<nlohmann::json>& validated_results)
+{
+    if (validated_results) {
+        if (auto result = find_result_for_po(*validated_results, unknown.value("po_id", ""))) {
+            lines.emplace_back(std::string("  validator_status: ")
+                               + result->value("validator_status", ""));
+            if (result->contains("downgrade_reason_code")) {
+                lines.emplace_back(std::string("  downgrade_reason: ")
+                                   + result->value("downgrade_reason_code", ""));
+            }
+        }
+    }
+}
+
+void append_text_block(std::vector<std::string>& lines,
+                       const nlohmann::json& unknown,
+                       const std::optional<nlohmann::json>& validated_results)
+{
+    lines.emplace_back(std::string("UNKNOWN: ") + unknown.value("unknown_stable_id", ""));
+    lines.emplace_back(std::string("  po_id: ") + unknown.value("po_id", ""));
+    lines.emplace_back(std::string("  code: ") + unknown.value("unknown_code", ""));
+
+    append_missing_lemma(lines, unknown);
+    append_refinement_plan(lines, unknown);
+    append_depends_on(lines, unknown);
+    append_validator_status(lines, unknown, validated_results);
+}
+
+[[nodiscard]] sappp::VoidResult write_json_output(const std::filesystem::path& path,
+                                                  const nlohmann::json& payload)
+{
+    std::ofstream out(path);
+    if (!out) {
+        return std::unexpected(
+            sappp::Error::make("IOError", "Failed to open output file: " + path.string()));
+    }
+    auto canonical = sappp::canonical::canonicalize(payload);
+    if (!canonical) {
+        return std::unexpected(canonical.error());
+    }
+    out << *canonical << "\n";
+    if (!out) {
+        return std::unexpected(
+            sappp::Error::make("IOError", "Failed to write output file: " + path.string()));
+    }
+    return {};
+}
+
+}  // namespace
+
+// NOLINTNEXTLINE(misc-use-internal-linkage): Public API defined in header.
+[[nodiscard]] sappp::Result<ExplainOutput> explain_unknowns(const ExplainOptions& options)
+{
+    auto unknown_payload = load_and_validate_unknown(options);
+    if (!unknown_payload) {
+        return std::unexpected(unknown_payload.error());
+    }
+
+    auto validated_payload = load_validated_results(options);
+    if (!validated_payload) {
+        return std::unexpected(validated_payload.error());
+    }
+
+    if (!unknown_payload->contains("unknowns")) {
+        return std::unexpected(
+            sappp::Error::make("SchemaInvalid", "unknown ledger missing unknowns array"));
+    }
+
+    std::vector<nlohmann::json> filtered_unknowns;
+    for (const auto& unknown : unknown_payload->at("unknowns")) {
+        if (matches_filters(unknown, options, *validated_payload)) {
+            filtered_unknowns.push_back(unknown);
+        }
+    }
+
+    std::stable_sort(filtered_unknowns.begin(),
+                     filtered_unknowns.end(),
+                     [](const nlohmann::json& lhs, const nlohmann::json& rhs) {
+                         return lhs.value("unknown_stable_id", "")
+                                < rhs.value("unknown_stable_id", "");
+                     });
+
+    ExplainOutput output;
+    output.format = options.format;
+    output.unknown_count = filtered_unknowns.size();
+    output.summary = std::format("UNKNOWN entries: {}", filtered_unknowns.size());
+
+    if (options.format == ExplainFormat::kJson) {
+        nlohmann::json payload = {
+            {"schema_version",                     "explain.v1"                              },
+            {          "tool",
+             {{"name", "sappp"}, {"version", sappp::kVersion}, {"build_id", sappp::kBuildId}}},
+            {  "generated_at",                                             current_time_utc()},
+            {      "unknowns",                                              filtered_unknowns}
+        };
+        if (validated_payload && *validated_payload) {
+            payload["validated_results"] = {
+                {"path", options.validated_path->string()}
+            };
+        }
+        output.json = std::move(payload);
+    } else {
+        std::vector<std::string> lines;
+        lines.emplace_back(output.summary);
+        for (const auto& unknown : filtered_unknowns) {
+            append_text_block(lines, unknown, *validated_payload);
+        }
+        output.text = std::move(lines);
+    }
+
+    return output;
+}
+
+[[nodiscard]] sappp::VoidResult write_explain_output(const ExplainOptions& options,
+                                                     const ExplainOutput& output)
+{
+    if (options.format == ExplainFormat::kJson) {
+        if (!options.output_path) {
+            return std::unexpected(
+                sappp::Error::make("MissingArgument", "--out is required for json output"));
+        }
+        return write_json_output(*options.output_path, output.json);
+    }
+
+    if (options.output_path) {
+        std::ofstream out(*options.output_path);
+        if (!out) {
+            return std::unexpected(
+                sappp::Error::make("IOError",
+                                   "Failed to open output file: " + options.output_path->string()));
+        }
+        for (const auto& line : output.text) {
+            out << line << "\n";
+        }
+        if (!out) {
+            return std::unexpected(sappp::Error::make("IOError",
+                                                      "Failed to write output file: "
+                                                          + options.output_path->string()));
+        }
+        return {};
+    }
+
+    for (const auto& line : output.text) {
+        std::println("{}", line);
+    }
+    return {};
+}
+
+}  // namespace sappp::report

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,9 @@ add_subdirectory(po)
 # Validator tests
 add_subdirectory(validator)
 
+# Report tests
+add_subdirectory(report)
+
 # Frontend (Clang) tests
 if(SAPPP_BUILD_CLANG_FRONTEND)
     add_subdirectory(frontend_clang)

--- a/tests/report/CMakeLists.txt
+++ b/tests/report/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_executable(test_report_explain
+    test_explain.cpp
+)
+
+sappp_target_strict_warnings(test_report_explain)
+
+target_link_libraries(test_report_explain PRIVATE
+    sappp_report
+    sappp_common
+    sappp_canonical
+    nlohmann_json::nlohmann_json
+    GTest::gtest_main
+)
+
+target_compile_definitions(test_report_explain PRIVATE
+    SAPPP_SCHEMA_DIR="${CMAKE_SOURCE_DIR}/schemas"
+)
+
+sappp_register_gtest(test_report_explain report)

--- a/tests/report/test_explain.cpp
+++ b/tests/report/test_explain.cpp
@@ -1,0 +1,135 @@
+/**
+ * @file test_explain.cpp
+ * @brief Tests for explain UNKNOWN report generation
+ */
+
+#include "sappp/report/explain.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace sappp::report::tests {
+
+namespace {
+
+constexpr std::string_view kShaPrefix = "sha256:";
+
+std::string make_sha256(char fill)
+{
+    return std::string(kShaPrefix) + std::string(64, fill);
+}
+
+std::filesystem::path write_json(const std::filesystem::path& path, const nlohmann::json& payload)
+{
+    std::ofstream out(path);
+    out << payload.dump(2);
+    return path;
+}
+
+nlohmann::json make_unknown_ledger()
+{
+    nlohmann::json unknown = {
+        {      "schema_version",                    "unknown.v1"                                },
+        {                "tool", {{"name", "sappp"}, {"version", "test"}, {"build_id", "local"}}},
+        {        "generated_at",                                          "2024-01-01T00:00:00Z"},
+        {               "tu_id",                                                make_sha256('a')},
+        {   "semantics_version",                                                        "sem.v1"},
+        {"proof_system_version",                                                      "proof.v1"},
+        {     "profile_version",                                                    "profile.v1"},
+        {            "unknowns",
+         nlohmann::json::array({nlohmann::json{
+         {"unknown_stable_id", make_sha256('b')},
+         {"po_id", make_sha256('c')},
+         {"unknown_code", "MissingLemma"},
+         {"missing_lemma",
+         {{"expr", {{"op", ">"}, {"args", nlohmann::json::array()}}},
+         {"pretty", "x > 0"},
+         {"symbols", nlohmann::json::array({"x"})}}},
+         {"refinement_plan",
+         {{"message", "Add precondition"},
+         {"actions", nlohmann::json::array({{{"action", "add_precondition"}}})}}}}})            }
+    };
+    return unknown;
+}
+
+nlohmann::json make_validated_results(std::string_view category)
+{
+    nlohmann::json results = {
+        {      "schema_version",          "validated_results.v1"                                },
+        {                "tool", {{"name", "sappp"}, {"version", "test"}, {"build_id", "local"}}},
+        {        "generated_at",                                          "2024-01-01T00:00:00Z"},
+        {               "tu_id",                                                make_sha256('a')},
+        {   "semantics_version",                                                        "sem.v1"},
+        {"proof_system_version",                                                      "proof.v1"},
+        {     "profile_version",                                                    "profile.v1"},
+        {             "results",
+         nlohmann::json::array({{{"po_id", make_sha256('c')},
+         {"category", std::string(category)},
+         {"validator_status", "Validated"}}})                                                   }
+    };
+    return results;
+}
+
+}  // namespace
+
+TEST(ExplainReportTest, GeneratesTextSummary)
+{
+    std::filesystem::path temp_root =
+        std::filesystem::temp_directory_path() / "sappp_explain_test_text";
+    std::filesystem::remove_all(temp_root);
+    std::filesystem::create_directories(temp_root);
+
+    auto unknown_path = write_json(temp_root / "unknown.json", make_unknown_ledger());
+
+    ExplainOptions options{.unknown_path = unknown_path,
+                           .validated_path = std::nullopt,
+                           .po_id = std::nullopt,
+                           .unknown_id = std::nullopt,
+                           .output_path = std::nullopt,
+                           .schema_dir = SAPPP_SCHEMA_DIR,
+                           .format = ExplainFormat::kText};
+
+    auto output = explain_unknowns(options);
+    ASSERT_TRUE(output);
+    EXPECT_EQ(output->unknown_count, 1U);
+    ASSERT_FALSE(output->text.empty());
+    EXPECT_EQ(output->text.front(), "UNKNOWN entries: 1");
+}
+
+TEST(ExplainReportTest, FiltersUsingValidatedResults)
+{
+    std::filesystem::path temp_root =
+        std::filesystem::temp_directory_path() / "sappp_explain_test_json";
+    std::filesystem::remove_all(temp_root);
+    std::filesystem::create_directories(temp_root);
+
+    auto unknown_path = write_json(temp_root / "unknown.json", make_unknown_ledger());
+    auto validated_path = write_json(temp_root / "validated.json", make_validated_results("SAFE"));
+
+    ExplainOptions options{.unknown_path = unknown_path,
+                           .validated_path = validated_path,
+                           .po_id = std::nullopt,
+                           .unknown_id = std::nullopt,
+                           .output_path = temp_root / "explain.json",
+                           .schema_dir = SAPPP_SCHEMA_DIR,
+                           .format = ExplainFormat::kJson};
+
+    auto output = explain_unknowns(options);
+    ASSERT_TRUE(output);
+    EXPECT_EQ(output->unknown_count, 0U);
+
+    auto write = write_explain_output(options, *output);
+    ASSERT_TRUE(write);
+
+    std::ifstream in(*options.output_path);
+    ASSERT_TRUE(in.is_open());
+    nlohmann::json payload;
+    in >> payload;
+    EXPECT_EQ(payload.at("schema_version"), "explain.v1");
+    EXPECT_EQ(payload.at("unknowns").size(), 0U);
+}
+
+}  // namespace sappp::report::tests

--- a/tools/sappp/CMakeLists.txt
+++ b/tools/sappp/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(sappp PRIVATE
     sappp_canonical
     sappp_build_capture
     sappp_po
+    sappp_report
     sappp_validator
     nlohmann_json::nlohmann_json
 )


### PR DESCRIPTION
### Motivation

- Provide a CLI-guided way to inspect and triage `unknown.v1` ledgers (UNKNOWN entries) to help developers iterate on missing lemmas and refinement plans.
- Integrate explain functionality into the `report` layer so the CLI can emit both human-readable text and canonical JSON explain outputs for downstream tooling.

### Description

- Added a report API and header: `include/sappp/report/explain.hpp` and implementation `libs/report/explain.cpp` that load/validate `unknown.v1` and optional `validated_results.v1`, filter entries, stable-sort by `unknown_stable_id`, and produce text or JSON (`explain.v1`) output and writers that use canonical JSON serialization.
- Wired the new report library into build files: `libs/report/CMakeLists.txt` (new library target) and linked `sappp_report` into the CLI in `tools/sappp/CMakeLists.txt`.
- Implemented CLI plumbing in `tools/sappp/main.cpp` to parse `sappp explain` options (`--unknown`, `--validated`, `--po`, `--unknown-id`, `--format`, `--out`, `--schema-dir`) and call the report API; added help text for the command.
- Added unit tests exercising explain behavior and filtering: `tests/report/test_explain.cpp` and CMake test registration `tests/report/CMakeLists.txt`, and registered report tests in `tests/CMakeLists.txt`.

### Testing

- Ran configure: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` which completed successfully.
- Attempted full build: `cmake --build build --parallel` which failed during compilation of `libs/report/explain.cpp`/`tools/sappp/main.cpp` due to missing `<print>` header in the toolchain (fatal error: `<print>` file not found), so tests were not run.
- Ran static checks: `clang-tidy` invocation also failed for the same reason (compiler header support for `<print>` missing), preventing completion of lint/clang-tidy gates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d9f71e6b8832daf268b1401958aca)