### PR TITLE
Add minimal schema fixtures and enable resolving sappp:schema references for validation

### DIFF
--- a/libs/common/schema_validate.cpp
+++ b/libs/common/schema_validate.cpp
@@ -5,8 +5,11 @@
 
 #include "sappp/schema_validate.hpp"
 
+#include <filesystem>
 #include <format>
 #include <fstream>
+#include <memory>
+#include <vector>
 
 #include <valijson/adapters/nlohmann_json_adapter.hpp>
 #include <valijson/schema.hpp>
@@ -104,10 +107,36 @@ sappp::VoidResult validate_json(const nlohmann::json& j, const std::string& sche
 
     valijson::Schema schema;
     valijson::SchemaParser parser;
+    const auto schema_dir = std::filesystem::path(schema_path).parent_path();
+    std::vector<std::unique_ptr<nlohmann::json>> owned_schemas;
+    const auto fetch_doc = [&schema_dir,
+                            &owned_schemas](const std::string& uri) -> const nlohmann::json* {
+        constexpr std::string_view kSchemaPrefix = "sappp:schema/";
+        if (!uri.starts_with(kSchemaPrefix)) {
+            return nullptr;
+        }
+        const auto schema_name = uri.substr(kSchemaPrefix.size());
+        auto schema_file = schema_dir / (schema_name + ".schema.json");
+        std::ifstream schema_file_stream(schema_file);
+        if (!schema_file_stream) {
+            return nullptr;
+        }
+        auto schema_ptr = std::make_unique<nlohmann::json>();
+        try {
+            schema_file_stream >> *schema_ptr;
+        } catch (const std::exception&) {
+            return nullptr;
+        }
+        normalize_schema_defs(*schema_ptr);
+        const auto* resolved_schema = schema_ptr.get();
+        owned_schemas.push_back(std::move(schema_ptr));
+        return resolved_schema;
+    };
+    const auto free_doc = [](const nlohmann::json* schema_ptr) { (void)schema_ptr; };
 
     try {
         valijson::adapters::NlohmannJsonAdapter schema_adapter(schema_json);
-        parser.populateSchema(schema_adapter, schema);
+        parser.populateSchema(schema_adapter, schema, fetch_doc, free_doc);
     } catch (const std::exception& ex) {
         return std::unexpected(
             Error::make("SchemaBuildFailed", std::string("Failed to build schema: ") + ex.what()));

--- a/tests/schemas/test_schema_validate.cpp
+++ b/tests/schemas/test_schema_validate.cpp
@@ -1,6 +1,8 @@
 #include "sappp/schema_validate.hpp"
 
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -19,11 +21,36 @@ std::string sha256_hex()
     return "sha256:" + std::string(64, 'a');
 }
 
+nlohmann::json make_tool_json()
+{
+    return nlohmann::json{
+        {   "name", "sappp"},
+        {"version", "0.1.0"}
+    };
+}
+
+nlohmann::json make_location_json()
+{
+    return nlohmann::json{
+        {"file", "main.c"},
+        {"line",        1},
+        { "col",        1}
+    };
+}
+
+nlohmann::json make_expr_json()
+{
+    return nlohmann::json{
+        {  "op",                   "and"},
+        {"args", nlohmann::json::array()}
+    };
+}
+
 nlohmann::json make_valid_unknown_json()
 {
     return nlohmann::json{
         {      "schema_version",                    "unknown.v1"                                },
-        {                "tool",                       {{"name", "sappp"}, {"version", "0.1.0"}}},
+        {                "tool",                                                make_tool_json()},
         {        "generated_at",                                          "2024-01-01T00:00:00Z"},
         {               "tu_id",                                                    sha256_hex()},
         {            "unknowns",
@@ -32,7 +59,7 @@ nlohmann::json make_valid_unknown_json()
          {"po_id", sha256_hex()},
          {"unknown_code", "U-TEST"},
          {"missing_lemma",
-         {{"expr", {{"op", "and"}, {"args", nlohmann::json::array()}}},
+         {{"expr", make_expr_json()},
          {"pretty", "x"},
          {"symbols", nlohmann::json::array({"x"})}}},
          {"refinement_plan", {{"message", "noop"}, {"actions", nlohmann::json::array()}}}}})    },
@@ -42,26 +69,279 @@ nlohmann::json make_valid_unknown_json()
     };
 }
 
-}  // namespace
-
-TEST(SchemaValidateTest, ValidUnknownSchemaPasses)
+struct SchemaCase
 {
-    nlohmann::json valid = make_valid_unknown_json();
-    auto result = sappp::common::validate_json(valid, schema_path("unknown.v1.schema.json"));
+    std::string schema_file;
+    nlohmann::json valid_json;
+};
 
-    EXPECT_TRUE(result);
+constexpr std::string_view kGeneratedAt = "2024-01-01T00:00:00Z";
+
+std::string generated_at_string()
+{
+    return std::string(kGeneratedAt);
 }
 
-TEST(SchemaValidateTest, InvalidUnknownSchemaFails)
+nlohmann::json make_analysis_config_json()
 {
-    nlohmann::json invalid = make_valid_unknown_json();
-    invalid["schema_version"] = "unknown.v2";
+    return nlohmann::json{
+        {      "schema_version",                   "analysis_config.v1"},
+        {                "tool",                       make_tool_json()},
+        {        "generated_at",                  generated_at_string()},
+        {   "semantics_version",                                   "v1"},
+        {"proof_system_version",                                   "v1"},
+        {     "profile_version",                                   "v1"},
+        {            "analysis", {{"budget", nlohmann::json::object()}}}
+    };
+}
 
-    auto result = sappp::common::validate_json(invalid, schema_path("unknown.v1.schema.json"));
+nlohmann::json make_build_snapshot_json()
+{
+    const auto sha = sha256_hex();
+    return nlohmann::json{
+        {"schema_version",   "build_snapshot.v1"                          },
+        {          "tool",                                make_tool_json()},
+        {  "generated_at",                           generated_at_string()},
+        {          "host",           {{"os", "linux"}, {"arch", "x86_64"}}},
+        { "compile_units",
+         nlohmann::json::array(
+         {{{"tu_id", sha},
+         {"cwd", "/repo"},
+         {"argv", nlohmann::json::array({"cc"})},
+         {"lang", "c"},
+         {"std", "c11"},
+         {"target",
+         {{"triple", "x86_64-unknown-linux-gnu"},
+         {"abi", "sysv"},
+         {"data_layout", {{"ptr_bits", 64}, {"long_bits", 64}, {"align", {{"max", 8}}}}}}},
+         {"frontend", {{"kind", "clang"}, {"version", "17.0.0"}}}}})      }
+    };
+}
 
-    EXPECT_FALSE(result);
-    ASSERT_FALSE(result);
-    EXPECT_FALSE(result.error().message.empty());
+nlohmann::json make_cert_po_def_json()
+{
+    const auto sha = sha256_hex();
+    const auto expr = make_expr_json();
+    return nlohmann::json{
+        {"schema_version","cert.v1"                          },
+        {          "kind",                          "PoDef"},
+        {            "po",
+         {{"po_id", sha},
+         {"po_kind", "div0"},
+         {"profile_version", "v1"},
+         {"semantics_version", "v1"},
+         {"proof_system_version", "v1"},
+         {"repo_identity", {{"path", "main.c"}, {"content_sha256", sha}}},
+         {"function", {{"usr", "usr:main"}, {"mangled", "_Z4mainv"}}},
+         {"anchor", {{"block_id", "B0"}, {"inst_id", "I0"}}},
+         {"predicate", {{"expr", expr}, {"pretty", "x"}}}} }
+    };
+}
+
+nlohmann::json make_cert_index_json()
+{
+    const auto sha = sha256_hex();
+    return nlohmann::json{
+        {"schema_version", "cert_index.v1"},
+        {         "po_id",             sha},
+        {          "root",             sha}
+    };
+}
+
+nlohmann::json make_contract_ir_json()
+{
+    const auto sha = sha256_hex();
+    return nlohmann::json{
+        {"schema_version",         "contract_ir.v1"},
+        {   "contract_id",                      sha},
+        {        "target",    {{"usr", "usr:main"}}},
+        {          "tier",                  "Tier0"},
+        { "version_scope", nlohmann::json::object()},
+        {      "contract", nlohmann::json::object()}
+    };
+}
+
+nlohmann::json make_diff_json()
+{
+    const auto sha = sha256_hex();
+    return nlohmann::json{
+        {"schema_version",   "diff.v1"                          },
+        {          "tool",                      make_tool_json()},
+        {  "generated_at",                 generated_at_string()},
+        {        "before",
+         {{"input_digest", sha},
+         {"semantics_version", "v1"},
+         {"proof_system_version", "v1"},
+         {"profile_version", "v1"},
+         {"results_digest", sha}}                               },
+        {         "after",
+         {{"input_digest", sha},
+         {"semantics_version", "v1"},
+         {"proof_system_version", "v1"},
+         {"profile_version", "v1"},
+         {"results_digest", sha}}                               },
+        {       "changes",
+         nlohmann::json::array({{{"po_id", sha},
+         {"from", {{"category", "UNKNOWN"}}},
+         {"to", {{"category", "UNKNOWN"}}},
+         {"change_kind", "Unchanged"}}})                        }
+    };
+}
+
+nlohmann::json make_nir_json()
+{
+    const auto sha = sha256_hex();
+    return nlohmann::json{
+        {   "schema_version","nir.v1"                             },
+        {             "tool",           make_tool_json()},
+        {     "generated_at",      generated_at_string()},
+        {            "tu_id",                        sha},
+        {"semantics_version",                       "v1"},
+        {        "functions",
+         nlohmann::json::array(
+         {{{"function_uid", "func:main"},
+         {"mangled_name", "_Z4mainv"},
+         {"cfg",
+         {{"entry", "B0"},
+         {"blocks",
+         nlohmann::json::array(
+         {{{"id", "B0"},
+         {"insts", nlohmann::json::array({{{"id", "I0"}, {"op", "ret"}}})}}})},
+         {"edges", nlohmann::json::array()}}}}})        }
+    };
+}
+
+nlohmann::json make_pack_manifest_json()
+{
+    const auto sha = sha256_hex();
+    return nlohmann::json{
+        {      "schema_version",              "pack_manifest.v1"                                },
+        {                "tool",                                                make_tool_json()},
+        {        "generated_at",                                           generated_at_string()},
+        {   "semantics_version",                                                            "v1"},
+        {"proof_system_version",                                                            "v1"},
+        {     "profile_version",                                                            "v1"},
+        {        "input_digest",                                                             sha},
+        {         "repro_level",                                                            "L0"},
+        {               "files",
+         nlohmann::json::array({{{"path", "out/nir.json"}, {"sha256", sha}, {"size_bytes", 0}}})}
+    };
+}
+
+nlohmann::json make_po_json()
+{
+    const auto sha = sha256_hex();
+    const auto expr = make_expr_json();
+    return nlohmann::json{
+        {"schema_version",                         "po.v1"                          },
+        {          "tool",                                          make_tool_json()},
+        {  "generated_at",                                     generated_at_string()},
+        {         "tu_id",                                                       sha},
+        {           "pos",
+         nlohmann::json::array({{{"po_id", sha},
+         {"po_kind", "div0"},
+         {"profile_version", "v1"},
+         {"semantics_version", "v1"},
+         {"proof_system_version", "v1"},
+         {"repo_identity", {{"path", "main.c"}, {"content_sha256", sha}}},
+         {"function", {{"usr", "usr:main"}, {"mangled", "_Z4mainv"}}},
+         {"anchor", {{"block_id", "B0"}, {"inst_id", "I0"}}},
+         {"predicate", {{"expr", expr}, {"pretty", "x"}}}}})                        }
+    };
+}
+
+nlohmann::json make_source_map_json()
+{
+    const auto sha = sha256_hex();
+    const auto location = make_location_json();
+    return nlohmann::json{
+        {"schema_version","source_map.v1"                          },
+        {          "tool",      make_tool_json()},
+        {  "generated_at", generated_at_string()},
+        {         "tu_id",                   sha},
+        {       "entries",
+         nlohmann::json::array(
+         {{{"ir_ref", {{"function_uid", "func:main"}, {"block_id", "B0"}, {"inst_id", "I0"}}},
+         {"spelling_loc", location},
+         {"expansion_loc", location}}})         }
+    };
+}
+
+nlohmann::json make_specdb_snapshot_json()
+{
+    return nlohmann::json{
+        {"schema_version",    "specdb_snapshot.v1"},
+        {          "tool",        make_tool_json()},
+        {  "generated_at",   generated_at_string()},
+        {     "contracts", nlohmann::json::array()}
+    };
+}
+
+nlohmann::json make_validated_results_json()
+{
+    const auto sha = sha256_hex();
+    return nlohmann::json{
+        {      "schema_version",       "validated_results.v1"                                },
+        {                "tool",                                             make_tool_json()},
+        {        "generated_at",                                        generated_at_string()},
+        {               "tu_id",                                                          sha},
+        {   "semantics_version",                                                         "v1"},
+        {"proof_system_version",                                                         "v1"},
+        {     "profile_version",                                                         "v1"},
+        {             "results",
+         nlohmann::json::array(
+         {{{"po_id", sha}, {"category", "UNKNOWN"}, {"validator_status", "Downgraded"}}})    }
+    };
+}
+
+std::vector<SchemaCase> make_schema_cases()
+{
+    return {
+        {  .schema_file = "analysis_config.v1.schema.json",
+         .valid_json = make_analysis_config_json()                                                  },
+        {   .schema_file = "build_snapshot.v1.schema.json", .valid_json = make_build_snapshot_json()},
+        {             .schema_file = "cert.v1.schema.json",    .valid_json = make_cert_po_def_json()},
+        {       .schema_file = "cert_index.v1.schema.json",     .valid_json = make_cert_index_json()},
+        {      .schema_file = "contract_ir.v1.schema.json",    .valid_json = make_contract_ir_json()},
+        {             .schema_file = "diff.v1.schema.json",           .valid_json = make_diff_json()},
+        {              .schema_file = "nir.v1.schema.json",            .valid_json = make_nir_json()},
+        {    .schema_file = "pack_manifest.v1.schema.json",  .valid_json = make_pack_manifest_json()},
+        {               .schema_file = "po.v1.schema.json",             .valid_json = make_po_json()},
+        {       .schema_file = "source_map.v1.schema.json",     .valid_json = make_source_map_json()},
+        {  .schema_file = "specdb_snapshot.v1.schema.json",
+         .valid_json = make_specdb_snapshot_json()                                                  },
+        {          .schema_file = "unknown.v1.schema.json",  .valid_json = make_valid_unknown_json()},
+        {.schema_file = "validated_results.v1.schema.json",
+         .valid_json = make_validated_results_json()                                                }
+    };
+}
+
+}  // namespace
+
+TEST(SchemaValidateTest, ValidSchemaSamplesPass)
+{
+    for (const auto& schema_case : make_schema_cases()) {
+        SCOPED_TRACE(schema_case.schema_file);
+        auto result = sappp::common::validate_json(schema_case.valid_json,
+                                                   schema_path(schema_case.schema_file));
+
+        EXPECT_TRUE(result);
+    }
+}
+
+TEST(SchemaValidateTest, InvalidSchemaSamplesFail)
+{
+    for (const auto& schema_case : make_schema_cases()) {
+        SCOPED_TRACE(schema_case.schema_file);
+        nlohmann::json invalid = schema_case.valid_json;
+        invalid["schema_version"] = "invalid.v0";
+
+        auto result = sappp::common::validate_json(invalid, schema_path(schema_case.schema_file));
+
+        EXPECT_FALSE(result);
+        ASSERT_FALSE(result);
+        EXPECT_FALSE(result.error().message.empty());
+    }
 }
 
 }  // namespace sappp::common::test


### PR DESCRIPTION
### Motivation
- Ensure every schema in `schemas/` has a minimal valid/invalid JSON exercised by unit tests so schema regressions are caught early. 
- Allow schema validator to resolve internal `sappp:schema/*` references so compound schemas that reference other schemas validate correctly. 

### Description
- Added fixture generators and a table-driven test in `tests/schemas/test_schema_validate.cpp` that supplies minimal valid JSON for each schema and verifies invalid `schema_version` failures. 
- Enhanced `libs/common/schema_validate.cpp` to register `fetchDoc`/`freeDoc` handlers for `valijson::SchemaParser` that load `sappp:schema/<name>` from the same `schemas/` directory and canonicalize `$defs` before parsing. 
- Use `std::unique_ptr` to manage fetched schema objects to satisfy ownership and static analysis constraints and keep `freeDoc` as a no-op. 
- Kept formatting and static checks in sync by running `clang-format` and `clang-tidy` on the modified files. 

### Testing
- Configured the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON` which configured successfully. 
- Ran `cmake --build build --parallel`; an unrelated tool build error was observed earlier due to a missing `<print>` header in `tools/sappp` but test binaries were ultimately produced for schema tests. 
- Executed unit tests with `ctest --test-dir build --output-on-failure` and all tests passed (44/44), including the new schema tests. 
- Ran determinism tests with `ctest --test-dir build -R determinism --output-on-failure` which also passed; `./scripts/pre-commit-check.sh` reported missing system toolchains (`g++-14` and `clang++-19`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d9e974edc832da295869c0ebb3208)