### PR TITLE
analyze: add specdb snapshot output and schema resolution for valijson

### DIFF
--- a/tests/schemas/test_schema_validate.cpp
+++ b/tests/schemas/test_schema_validate.cpp
@@ -42,6 +42,16 @@ nlohmann::json make_valid_unknown_json()
     };
 }
 
+nlohmann::json make_valid_specdb_snapshot()
+{
+    return nlohmann::json{
+        {"schema_version",                      "specdb_snapshot.v1"},
+        {          "tool", {{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                    "2024-01-01T00:00:00Z"},
+        {     "contracts",                   nlohmann::json::array()}
+    };
+}
+
 }  // namespace
 
 TEST(SchemaValidateTest, ValidUnknownSchemaPasses)
@@ -58,6 +68,28 @@ TEST(SchemaValidateTest, InvalidUnknownSchemaFails)
     invalid["schema_version"] = "unknown.v2";
 
     auto result = sappp::common::validate_json(invalid, schema_path("unknown.v1.schema.json"));
+
+    EXPECT_FALSE(result);
+    ASSERT_FALSE(result);
+    EXPECT_FALSE(result.error().message.empty());
+}
+
+TEST(SchemaValidateTest, ValidSpecdbSnapshotPasses)
+{
+    nlohmann::json valid = make_valid_specdb_snapshot();
+    auto result =
+        sappp::common::validate_json(valid, schema_path("specdb_snapshot.v1.schema.json"));
+
+    EXPECT_TRUE(result);
+}
+
+TEST(SchemaValidateTest, InvalidSpecdbSnapshotFails)
+{
+    nlohmann::json invalid = make_valid_specdb_snapshot();
+    invalid.erase("contracts");
+
+    auto result =
+        sappp::common::validate_json(invalid, schema_path("specdb_snapshot.v1.schema.json"));
 
     EXPECT_FALSE(result);
     ASSERT_FALSE(result);


### PR DESCRIPTION
### Motivation
- Ensure `sappp analyze` emits `specdb_snapshot.v1` alongside other analyze outputs so `pack`/`diff` and validation have the expected inputs. 
- Make schema validation robust by enabling local resolution of `sappp:schema/*` JSON Schema references so multi-file schemas (e.g. `specdb_snapshot.v1`) validate correctly.

### Description
- Added `specdb` output directory and `specdb/snapshot.json` path to `AnalyzePaths` and the analyze output help text in `tools/sappp/main.cpp`.
- Implemented `load_specdb_snapshot()` that either loads a provided `--spec` file (and validates it) or generates a deterministic empty `specdb_snapshot.v1` when not provided, and write routines `write_specdb_snapshot_output`, `write_analysis_config_output`, and `write_unknown_ledger_output` to serialize canonical JSON outputs.
- Implemented valijson fetch/free callbacks in `libs/common/schema_validate.cpp` to resolve `sappp:schema/*` URIs (and local relative URIs) by loading referenced schema files from the same schema directory before populating the valijson `Schema`.
- Added schema unit tests `tests/schemas/test_schema_validate.cpp` to validate `specdb_snapshot.v1` success/failure cases and wired formatting/tidy adjustments.

### Testing
- Built with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON` and `cmake --build build --parallel`, which completed successfully.
- Ran unit tests with `ctest --test-dir build --output-on-failure` and determinism checks with `ctest --test-dir build -R determinism --output-on-failure`, and all tests passed (46 total; determinism subset passed).
- Executed static checks via `./scripts/agent-final-check.sh` (which installed required tools such as `clang-19` and `ajv-cli` in the environment), and the full pre-commit CI script completed with all checks passing.
- Ran `clang-format` and `clang-tidy` on the modified files and addressed warnings so tidy/format checks passed during the final check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef615bd48832d88abc05b780877cc)