### PR TITLE
Align unknown ledger generated_at with input metadata

### DIFF
--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -377,10 +377,18 @@ collect_ordered_pos(const nlohmann::json& po_list)
                                                        const nlohmann::json& tool_obj,
                                                        std::string_view tu_id)
 {
+    std::string generated_at = current_time_utc();
+    if (nir_json.contains("generated_at") && nir_json.at("generated_at").is_string()) {
+        generated_at = nir_json.at("generated_at").get<std::string>();
+    } else if (po_list_json.contains("generated_at")
+               && po_list_json.at("generated_at").is_string()) {
+        generated_at = po_list_json.at("generated_at").get<std::string>();
+    }
+
     nlohmann::json unknown_ledger = {
         {      "schema_version",            "unknown.v1"},
         {                "tool",                tool_obj},
-        {        "generated_at",      current_time_utc()},
+        {        "generated_at",            generated_at},
         {               "tu_id",      std::string(tu_id)},
         {            "unknowns", nlohmann::json::array()},
         {   "semantics_version",      versions.semantics},


### PR DESCRIPTION
### Motivation
- Ensure `unknown.v1` ledgers use existing `generated_at` metadata from `nir` or `po_list` when present so ledger timestamps are input-derived and more deterministic.

### Description
- Prefer `nir_json["generated_at"]` or `po_list_json["generated_at"]` when constructing the unknown ledger in `build_unknown_ledger_base` and fall back to `current_time_utc()` otherwise (change in `libs/analyzer/analyzer.cpp`).

### Testing
- Ran the full developer checks: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14`, `cmake --build build --parallel`, `ctest --test-dir build --output-on-failure`, `ctest --test-dir build -R determinism --output-on-failure`, `clang-tidy -p build libs/analyzer/analyzer.cpp`, and `./scripts/agent-final-check.sh`, all of which completed successfully (tests and determinism checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f29a169e0832d98312cfc167edabe)