### PR TITLE
Add end-to-end litmus tests for div0 / null / oob

### DIFF
--- a/tests/end_to_end/CMakeLists.txt
+++ b/tests/end_to_end/CMakeLists.txt
@@ -4,3 +4,25 @@
 add_subdirectory(litmus_div0)
 add_subdirectory(litmus_null)
 add_subdirectory(litmus_oob)
+
+if(SAPPP_BUILD_CLANG_FRONTEND)
+    add_executable(test_litmus_e2e
+        test_litmus_e2e.cpp
+    )
+
+    sappp_target_strict_warnings(test_litmus_e2e)
+
+    target_link_libraries(test_litmus_e2e PRIVATE
+        GTest::gtest_main
+        nlohmann_json::nlohmann_json
+    )
+
+    target_compile_definitions(test_litmus_e2e PRIVATE
+        SAPPP_REPO_ROOT=\"${CMAKE_SOURCE_DIR}\"
+        SAPPP_BIN_DIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}\"
+    )
+
+    add_dependencies(test_litmus_e2e sappp)
+
+    sappp_register_gtest(test_litmus_e2e slow)
+endif()

--- a/tests/end_to_end/litmus_div0.c
+++ b/tests/end_to_end/litmus_div0.c
@@ -1,0 +1,14 @@
+// Litmus test: Division by zero
+// Expected: BUG (div0 is reachable)
+
+int divide(int a, int b)
+{
+    return a / b;  // PO: b != 0
+}
+
+int main(void)
+{
+    int x = 10;
+    int y = 0;
+    return divide(x, y);  // BUG: y == 0
+}

--- a/tests/end_to_end/litmus_null.c
+++ b/tests/end_to_end/litmus_null.c
@@ -1,0 +1,13 @@
+// Litmus test: Null pointer dereference
+// Expected: BUG (null deref is reachable)
+
+int deref(const int* ptr)
+{
+    return *ptr;  // PO: ptr != 0
+}
+
+int main(void)
+{
+    int* p = (int*)0;
+    return deref(p);  // BUG: p == 0
+}

--- a/tests/end_to_end/litmus_oob.c
+++ b/tests/end_to_end/litmus_oob.c
@@ -1,0 +1,13 @@
+// Litmus test: Out-of-bounds array access
+// Expected: BUG (OOB is reachable)
+
+int access(const int* arr, int idx)
+{
+    return arr[idx];  // PO: 0 <= idx < len
+}
+
+int main(void)
+{
+    int arr[5] = {1, 2, 3, 4, 5};
+    return access(arr, 10);  // BUG: idx >= len
+}

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -1,0 +1,164 @@
+/**
+ * @file test_litmus_e2e.cpp
+ * @brief End-to-end litmus tests for div0/null/oob.
+ */
+
+#include <cstdlib>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+class TempDir
+{
+public:
+    explicit TempDir(const std::string& name)
+        : m_path(fs::temp_directory_path() / name)
+    {
+        fs::remove_all(m_path);
+        fs::create_directories(m_path);
+    }
+
+    ~TempDir()
+    {
+        std::error_code ec;
+        fs::remove_all(m_path, ec);
+    }
+
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+    TempDir(TempDir&&) = delete;
+    TempDir& operator=(TempDir&&) = delete;
+
+    [[nodiscard]] const fs::path& path() const { return m_path; }
+
+private:
+    fs::path m_path;
+};
+
+[[nodiscard]] std::string quote_path(const fs::path& path)
+{
+    return std::format("\"{}\"", path.string());
+}
+
+[[nodiscard]] int run_command(const std::string& command)
+{
+    return std::system(command.c_str());
+}
+
+void write_compile_commands(const fs::path& output,
+                            const fs::path& repo_root,
+                            const fs::path& source)
+{
+    nlohmann::json compile_db = nlohmann::json::array();
+    compile_db.push_back({
+        {"directory",                           repo_root.string()},
+        {     "file",                              source.string()},
+        {"arguments", {"clang", "-std=c11", "-c", source.string()}}
+    });
+
+    std::ofstream out(output);
+    out << compile_db.dump(2);
+}
+
+void expect_bug_result(const fs::path& validated_results)
+{
+    std::ifstream in(validated_results);
+    ASSERT_TRUE(in.is_open()) << "Failed to open " << validated_results.string();
+    nlohmann::json json = nlohmann::json::parse(in);
+
+    ASSERT_TRUE(json.contains("results")) << "validated_results missing results";
+    ASSERT_TRUE(json.at("results").is_array());
+
+    bool has_bug = false;
+    for (const auto& result : json.at("results")) {
+        if (result.contains("category") && result.at("category") == "BUG") {
+            has_bug = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(has_bug) << "Expected BUG entry in validated_results";
+}
+
+void run_litmus_case(const std::string& case_name, const fs::path& source_path)
+{
+    const fs::path repo_root = SAPPP_REPO_ROOT;
+    const fs::path sappp_bin = fs::path(SAPPP_BIN_DIR) / "sappp";
+    const fs::path schema_dir = repo_root / "schemas";
+
+    TempDir temp_dir(std::format("sappp_e2e_{}", case_name));
+    fs::path work_dir = temp_dir.path() / case_name;
+    fs::create_directories(work_dir);
+
+    fs::path compile_commands = work_dir / "compile_commands.json";
+    fs::path out_dir = work_dir / "out";
+    fs::path build_snapshot = out_dir / "build_snapshot.json";
+    fs::path pack_path = work_dir / "pack.tar.gz";
+    fs::path diff_path = work_dir / "diff.json";
+
+    write_compile_commands(compile_commands, repo_root, source_path);
+
+    std::string base = std::format("cd {} && {}", quote_path(repo_root), quote_path(sappp_bin));
+
+    std::string capture_cmd =
+        std::format("{} capture --compile-commands {} --out {} --repo-root {}",
+                    base,
+                    quote_path(compile_commands),
+                    quote_path(build_snapshot),
+                    quote_path(repo_root));
+    ASSERT_EQ(run_command(capture_cmd), 0) << capture_cmd;
+
+    std::string analyze_cmd = std::format("{} analyze --build {} --out {} --schema-dir {} --jobs 1",
+                                          base,
+                                          quote_path(build_snapshot),
+                                          quote_path(out_dir),
+                                          quote_path(schema_dir));
+    ASSERT_EQ(run_command(analyze_cmd), 0) << analyze_cmd;
+
+    std::string validate_cmd = std::format("{} validate --in {} --schema-dir {}",
+                                           base,
+                                           quote_path(out_dir),
+                                           quote_path(schema_dir));
+    ASSERT_EQ(run_command(validate_cmd), 0) << validate_cmd;
+
+    fs::path validated_results = out_dir / "results" / "validated_results.json";
+    ASSERT_TRUE(fs::exists(validated_results)) << validated_results.string();
+    expect_bug_result(validated_results);
+
+    std::string pack_cmd =
+        std::format("{} pack --in {} --out {}", base, quote_path(out_dir), quote_path(pack_path));
+    ASSERT_EQ(run_command(pack_cmd), 0) << pack_cmd;
+    ASSERT_TRUE(fs::exists(pack_path)) << pack_path.string();
+
+    std::string diff_cmd = std::format("{} diff --before {} --after {} --out {}",
+                                       base,
+                                       quote_path(pack_path),
+                                       quote_path(pack_path),
+                                       quote_path(diff_path));
+    ASSERT_EQ(run_command(diff_cmd), 0) << diff_cmd;
+    ASSERT_TRUE(fs::exists(diff_path)) << diff_path.string();
+}
+
+}  // namespace
+
+TEST(LitmusE2E, Div0)
+{
+    run_litmus_case("div0", fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_div0.c");
+}
+
+TEST(LitmusE2E, NullDeref)
+{
+    run_litmus_case("null", fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_null.c");
+}
+
+TEST(LitmusE2E, OutOfBounds)
+{
+    run_litmus_case("oob", fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_oob.c");
+}


### PR DESCRIPTION
### Motivation
- Provide minimal E2E litmus coverage to satisfy issue #22 by exercising the capture→analyze→validate→pack→diff pipeline for core BUG cases (div0, null deref, out-of-bounds).
- Ensure the project has automated E2E tests that assert a BUG result is produced and recorded in `validated_results.v1` for the three litmus inputs.

### Description
- Added three C litmus inputs under `tests/end_to_end`: `litmus_div0.c`, `litmus_null.c`, and `litmus_oob.c` containing minimal programs that trigger div0, null-deref, and OOB respectively.
- Added a GTest harness `tests/end_to_end/test_litmus_e2e.cpp` that runs the CLI flow (`sappp capture`, `sappp analyze`, `sappp validate`, `sappp pack`, `sappp diff`) via `system()` calls and asserts that `validated_results.json` contains a `BUG` entry.
- Registered the E2E test in `tests/end_to_end/CMakeLists.txt` and only build/register the test when `SAPPP_BUILD_CLANG_FRONTEND` is enabled, and added `SAPPP_REPO_ROOT` / `SAPPP_BIN_DIR` compile definitions to locate the built `sappp` binary and schemas.

### Testing
- Ran `clang-format -i tests/end_to_end/test_litmus_e2e.cpp` to format the new test file (succeeded).
- Attempted configure with the clang frontend enabled via `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON` (configuration failed due to missing Clang libs: `/usr/lib/llvm-20/lib/libclangBasic.a`).
- Configured with frontend disabled via `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON` (configuration succeeded), then `cmake --build build --parallel` was attempted but the build failed when compiling the `sappp` binary because the environment Clang is `clang++-17` which lacks the C++23 `<print>` header (fatal: `#include <print>` file not found).
- No `ctest` run was possible because the build did not complete; the new E2E test is registered and will run when the project is built in an environment with the Clang frontend and a C++23 toolchain that provides `<print>` and the full Clang libraries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fae4b1dc4832d93316f1171a0fb2b)