### PR TITLE
CTest登録を安定化する

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,9 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 include(GoogleTest)
-set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
+include(CTest)
+enable_testing()
+set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE POST_BUILD)
 
 # テストラベル定義
 # - quick: 高速テスト（30秒以内で完了すべき）
@@ -38,7 +40,7 @@ function(sappp_register_gtest target label)
     string(REPLACE ";" "\\;" test_labels_escaped "${test_labels}")
     
     gtest_discover_tests(${target}
-        DISCOVERY_MODE PRE_TEST
+        DISCOVERY_MODE POST_BUILD
         TEST_PREFIX "${label}."
         PROPERTIES LABELS "${test_labels_escaped}"
     )


### PR DESCRIPTION
### Motivation
- CTest が有効化されていない/GoogleTest の自動検出モードが PRE_TEST のままだと `ctest` 実行時にテストが正しく登録されないため、ビルドフローとテスト検出の安定化を図る。

### Description
- `tests/CMakeLists.txt` に `include(CTest)` と `enable_testing()` を追加して CTest を明示的に有効化した。 (`tests/CMakeLists.txt`)  
- `gtest_discover_tests` の `DISCOVERY_MODE` を `PRE_TEST` から `POST_BUILD` に変更し、テストの検出をビルド完了後に行うように統一した。 (`tests/CMakeLists.txt`)

### Testing
- 実行したコマンド: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON` は構成に成功した。  
- 実行したコマンド: `cmake --build build --parallel` はビルド中に `tools/sappp/main.cpp` の `#include <print>` が見つからず失敗したため、`ctest --test-dir build --output-on-failure` と `ctest --test-dir build -R determinism --output-on-failure` は未実行である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fae3f6220832d963ed5222a26a2cc)