### PR TITLE
Validator: BugTrace replay with NIR support and points-to checks

### DIFF
--- a/libs/validator/validator.cpp
+++ b/libs/validator/validator.cpp
@@ -577,8 +577,7 @@ validate_bug_trace_path(const ValidationContext& context,
                 return unsupported_error("BugTrace spans multiple functions");
             }
             if (block_id == prev_block_id) {
-                if (inst_ref.index < prev_inst.index
-                    && !prev_block->successors.contains(prev_block_id)) {
+                if (inst_ref.index < prev_inst.index) {
                     return proof_failed_error("BugTrace jumps backwards within block");
                 }
             } else if (!prev_block->successors.contains(block_id)) {


### PR DESCRIPTION
### Motivation
- Allow the Validator to replay BugTrace paths using the canonical NIR so SAFE/BUG conclusions that depend on lifetime/exception/virtual-call events can be validated.
- Reflect points-to information in SafetyProof checks so inconsistent or conflicting points-to state downgrades SAFE proofs to UNKNOWN.
- Avoid re-running frontends inside the Validator by loading an indexed NIR snapshot, preserving TCB boundaries and deterministic verification.

### Description
- Load and index `frontend/nir.json` in `libs/validator/validator.cpp` (NIR schema validation and `NirIndex` builder) and wire the index into the validation context.
- Implement `validate_bug_trace_path` to replay `BugTrace` steps against the NIR, verify supported IR ops, and perform CFG connectivity checks; the supported ops list was extended to include lifetime/ctor/dtor/move, exception ops (`invoke`/`throw`/`landingpad`/`resume`) and `vcall`.
- Add points-to consistency checks (`check_points_to_entries`) and accept additional safety-domain strings that include points-to variants in `is_supported_safety_domain`.
- Add unit tests and NIR test fixtures in `tests/validator/test_validator.cpp`, including `ValidatesBugTraceWithLifetimeExceptionVcall` and `DowngradesOnConflictingPointsToState`, and update test helpers to write minimal NIR JSON for the validator.

### Testing
- Ran `clang-format` on modified files successfully to satisfy formatting requirements.
- Configured the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON`, which completed successfully.
- Attempted `cmake --build build --parallel`, which compiled many targets (including the new/updated validator and `test_validator`) but the overall build failed when compiling `tools/sappp` due to a missing `<print>` header with Clang 17 in this environment, so `ctest` was not executed.
- As a result, the new validator unit tests were added but not run in this environment because the build was not completed; full CI/local Docker checks are recommended to run `ctest --test-dir build --output-on-failure` and determinism tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972e110eb30832d97385d84dc88bc2d)