### PR TITLE
Analyzer: apply SpecDB contracts to evidence and emit ContractRef deps

### DIFF
--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -256,13 +256,11 @@ resolve_function_uid(const std::unordered_map<std::string, std::string>& mapping
 struct ContractMatchSummary
 {
     std::vector<const ContractInfo*> contracts;
-    bool has_pre;
+    bool has_pre = false;
 
     ContractMatchSummary()
         // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
         : contracts()
-        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
-        , has_pre(false)
     {}
 };
 

--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -194,9 +194,10 @@ build_contract_index(const nlohmann::json* specdb_snapshot)
 
     for (auto& [usr, contracts] : index) {
         (void)usr;
-        std::ranges::stable_sort(contracts, [](const ContractInfo& a, const ContractInfo& b) {
-            return a.contract_id < b.contract_id;
-        });
+        std::ranges::stable_sort(contracts,
+                                 [](const ContractInfo& a, const ContractInfo& b) noexcept {
+                                     return a.contract_id < b.contract_id;
+                                 });
     }
 
     return index;
@@ -255,7 +256,14 @@ resolve_function_uid(const std::unordered_map<std::string, std::string>& mapping
 struct ContractMatchSummary
 {
     std::vector<const ContractInfo*> contracts;
-    bool has_pre = false;
+    bool has_pre;
+
+    ContractMatchSummary()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : contracts()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        , has_pre(false)
+    {}
 };
 
 [[nodiscard]] sappp::Result<ContractMatchSummary>

--- a/libs/analyzer/analyzer.hpp
+++ b/libs/analyzer/analyzer.hpp
@@ -32,7 +32,8 @@ public:
     explicit Analyzer(AnalyzerConfig config);
 
     [[nodiscard]] sappp::Result<AnalyzeOutput> analyze(const nlohmann::json& nir_json,
-                                                       const nlohmann::json& po_list_json) const;
+                                                       const nlohmann::json& po_list_json,
+                                                       const nlohmann::json* specdb_snapshot) const;
 
 private:
     AnalyzerConfig m_config;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE POST_BUILD)
 # - determinism: 決定性テスト
 # - benchmark: ベンチマークテスト
 set(SAPPP_QUICK_LABELS
+    analyzer
     build_capture
     determinism
     po
@@ -55,6 +56,9 @@ add_subdirectory(build_capture)
 
 # Determinism tests
 add_subdirectory(determinism)
+
+# Analyzer tests
+add_subdirectory(analyzer)
 
 # Report tests
 add_subdirectory(report)

--- a/tests/analyzer/CMakeLists.txt
+++ b/tests/analyzer/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(analyzer_tests
+    test_analyzer_contracts.cpp
+)
+
+sappp_target_strict_warnings(analyzer_tests)
+
+target_compile_definitions(analyzer_tests PRIVATE
+    SAPPP_SCHEMA_DIR="${CMAKE_SOURCE_DIR}/schemas"
+)
+
+target_link_libraries(analyzer_tests PRIVATE
+    sappp_analyzer
+    sappp_certstore
+    GTest::gtest_main
+)
+
+sappp_register_gtest(analyzer_tests analyzer)

--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -1,0 +1,170 @@
+#include "analyzer.hpp"
+#include "sappp/certstore.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace sappp::analyzer::test {
+
+namespace {
+
+std::string make_sha256(char fill)
+{
+    return std::string("sha256:") + std::string(64, fill);
+}
+
+std::filesystem::path ensure_temp_dir(const std::string& name)
+{
+    auto temp_dir = std::filesystem::temp_directory_path() / name;
+    std::error_code ec;
+    std::filesystem::remove_all(temp_dir, ec);
+    std::filesystem::create_directories(temp_dir, ec);
+    return temp_dir;
+}
+
+nlohmann::json make_nir()
+{
+    return nlohmann::json{
+        {"schema_version",                                                "nir.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {     "functions",                                 nlohmann::json::array()}
+    };
+}
+
+nlohmann::json make_po_list()
+{
+    nlohmann::json po = {
+        {               "po_id",            make_sha256('b')                                },
+        {             "po_kind",                                                "UB.DivZero"},
+        {     "profile_version",                                            "safety.core.v1"},
+        {   "semantics_version",                                                    "sem.v1"},
+        {"proof_system_version",                                                  "proof.v1"},
+        {       "repo_identity",
+         nlohmann::json{{"path", "src/main.cpp"}, {"content_sha256", make_sha256('c')}}     },
+        {            "function", nlohmann::json{{"usr", "usr::foo"}, {"mangled", "_Z3foov"}}},
+        {              "anchor",       nlohmann::json{{"block_id", "B1"}, {"inst_id", "I1"}}},
+        {           "predicate",
+         nlohmann::json{
+         {"expr", nlohmann::json{{"op", "custom.op"}, {"args", nlohmann::json::array({true})}}},
+         {"pretty", "custom"}}                                                              }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                 "po.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {           "pos",                             nlohmann::json::array({po})}
+    };
+}
+
+nlohmann::json make_contract_snapshot(bool include_contract)
+{
+    nlohmann::json contracts = nlohmann::json::array();
+    if (include_contract) {
+        contracts.push_back(nlohmann::json{
+            {"schema_version",                    "contract_ir.v1"                              },
+            {   "contract_id",                                                  make_sha256('d')},
+            {        "target",                               nlohmann::json{{"usr", "usr::foo"}}},
+            {          "tier",                                                           "Tier1"},
+            { "version_scope",
+             nlohmann::json{{"abi", "x86_64"},
+             {"library_version", "1.0.0"},
+             {"conditions", nlohmann::json::array()},
+             {"priority", 0}}                                                                   },
+            {      "contract",
+             nlohmann::json{
+             {"pre",
+             nlohmann::json{{"expr", nlohmann::json{{"op", "true"}}}, {"pretty", "true"}}}}     }
+        });
+    }
+
+    return nlohmann::json{
+        {"schema_version",                                    "specdb_snapshot.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {     "contracts",                                               contracts}
+    };
+}
+
+}  // namespace
+
+TEST(AnalyzerContractTest, AddsContractRefsAndKeepsUnknownDetails)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_contracts");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    auto nir = make_nir();
+    auto po_list = make_po_list();
+    auto specdb_snapshot = make_contract_snapshot(true);
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    ASSERT_EQ(unknowns.size(), 1U);
+    EXPECT_EQ(unknowns.at(0).at("unknown_code"), "DomainTooWeak.Numeric");
+    ASSERT_TRUE(unknowns.at(0).contains("depends_on"));
+    const auto& contracts = unknowns.at(0).at("depends_on").at("contracts");
+    ASSERT_EQ(contracts.size(), 1U);
+    EXPECT_EQ(contracts.at(0).get<std::string>(), make_sha256('d'));
+
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    ASSERT_TRUE(root_cert->at("depends").contains("contracts"));
+    std::string contract_ref_hash =
+        root_cert->at("depends").at("contracts").at(0).at("ref").get<std::string>();
+
+    auto contract_cert = cert_store.get(contract_ref_hash);
+    ASSERT_TRUE(contract_cert);
+    EXPECT_EQ(contract_cert->at("kind"), "ContractRef");
+    EXPECT_EQ(contract_cert->at("contract_id"), make_sha256('d'));
+}
+
+TEST(AnalyzerContractTest, MissingContractProducesUnknownCode)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_missing_contracts");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    auto nir = make_nir();
+    auto po_list = make_po_list();
+    auto specdb_snapshot = make_contract_snapshot(false);
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    ASSERT_EQ(unknowns.size(), 1U);
+    EXPECT_EQ(unknowns.at(0).at("unknown_code"), "MissingContract.Pre");
+    EXPECT_FALSE(unknowns.at(0).contains("depends_on"));
+}
+
+}  // namespace sappp::analyzer::test


### PR DESCRIPTION
### Motivation
- Reduce MissingContract.* UNKNOWNs by applying SpecDB-provided contracts during analysis so analyzer can attach contract evidence and lower spurious UNKNOWNs. 
- Reflect contract dependencies in produced certificate graph so Validator can consider contract tiers when deciding SAFE/BUG. 
- Add unit tests to assert contract-aware behavior and to prevent regressions. 

### Description
- Analyzer API extended: `Analyzer::analyze` now accepts an optional `specdb_snapshot` pointer and builds an in-memory `ContractIndex`. 
- Analyzer now matches PO function targets against the `specdb_snapshot` and emits `ContractRef` CAS objects for referenced contracts, adding contract refs into dependency graphs (`DependencyGraph`) and `ProofRoot.depends.contracts`. 
- Unknown ledger entries (`unknown.v1`) for MissingContract cases now include `depends_on.contracts` when applicable and the analyzer will emit `MissingContract.Pre` when no suitable precondition contract is present. 
- CLI integration: `tools/sappp` writes/reads the specdb snapshot and passes it into the analyzer invocation. 
- Tests: new analyzer unit tests added under `tests/analyzer` (`test_analyzer_contracts.cpp`) and wired into `tests/CMakeLists.txt`; implemented deterministic sorting/uniquing and small clang-format/clang-tidy adjustments. 

### Testing
- Configured build: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON` which completed configure successfully. 
- Build: `cmake --build build --parallel` partially succeeded; library/tests built and new analyzer tests built, but `tools/sappp` failed to compile in this toolchain due to missing `<print>` header in the environment so full `sappp` binary was not produced. 
- Unit tests: `ctest --test-dir build --output-on-failure` ran the test suite; most tests passed and the new analyzer tests passed (2 analyzer tests), but one determinism E2E test failed because the `sappp` CLI binary was not available (build failure above). 
- Determinism-only: `ctest --test-dir build -R determinism --output-on-failure` showed 97% pass and 1 failing determinism E2E because `build/bin/sappp` was not found. 
- Lint/format: `clang-format` was run on modified files; `clang-tidy` invocation surfaced the same header/toolchain limitations (warnings/errors tied to unavailable headers/toolchain.) 

Notes: the changes include new tests and analyzer behavior; a full CI run in the target environment (with the expected toolchain headers such as `<print>` and required compilers) is required to complete the final CI gates (build all binaries and pass determinism E2E).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b78c62cc832da8ccc87cd5fb050a)