### PR TITLE
MB9 tests: expand litmus/e2e/determinism

### DIFF
--- a/tests/end_to_end/litmus_double_free.cpp
+++ b/tests/end_to_end/litmus_double_free.cpp
@@ -1,0 +1,13 @@
+// Litmus test: Double free
+// Expected: UNKNOWN (DoubleFree)
+
+void sappp_sink(const char* kind);
+
+int main()
+{
+    int* ptr = new int(7);
+    delete ptr;
+    sappp_sink("double_free");
+    delete ptr;
+    return 0;
+}

--- a/tests/end_to_end/litmus_double_free.cpp
+++ b/tests/end_to_end/litmus_double_free.cpp
@@ -7,7 +7,7 @@ int main()
 {
     int* ptr = new int(7);
     delete ptr;
-    sappp_sink("double_free");
+    sappp_sink("double-free");
     delete ptr;
     return 0;
 }

--- a/tests/end_to_end/litmus_exception_raii.cpp
+++ b/tests/end_to_end/litmus_exception_raii.cpp
@@ -1,5 +1,5 @@
 // Litmus test: Exception RAII
-// Expected: SAFE (UB.Shift) plus exception/lifetime/vcall ops in NIR
+// Expected: SAFE (UB.Shift) plus exception/lifetime ops in NIR
 
 void sappp_check(const char* kind, bool predicate);
 

--- a/tests/end_to_end/litmus_exception_raii.cpp
+++ b/tests/end_to_end/litmus_exception_raii.cpp
@@ -1,0 +1,23 @@
+// Litmus test: Exception RAII
+// Expected: SAFE (UB.Shift) plus exception/lifetime/vcall ops in NIR
+
+void sappp_check(const char* kind, bool predicate);
+
+struct Guard
+{
+    ~Guard() {}
+};
+
+void may_throw();
+
+int main()
+{
+    try {
+        Guard guard;
+        may_throw();
+        sappp_check("shift", false);
+        throw 1;
+    } catch (...) {
+        return 0;
+    }
+}

--- a/tests/end_to_end/litmus_uninit_read.cpp
+++ b/tests/end_to_end/litmus_uninit_read.cpp
@@ -1,0 +1,11 @@
+// Litmus test: Uninitialized read
+// Expected: UNKNOWN (UninitRead)
+
+void sappp_sink(const char* kind);
+
+int main()
+{
+    int value;
+    sappp_sink("uninit_read");
+    return value;
+}

--- a/tests/end_to_end/litmus_use_after_lifetime.cpp
+++ b/tests/end_to_end/litmus_use_after_lifetime.cpp
@@ -1,0 +1,15 @@
+// Litmus test: Use-after-lifetime
+// Expected: UNKNOWN (UseAfterLifetime)
+
+void sappp_sink(const char* kind);
+
+int main()
+{
+    int* ptr = nullptr;
+    {
+        int use_after_lifetime = 42;
+        ptr = &use_after_lifetime;
+    }
+    sappp_sink("use-after-lifetime");
+    return *ptr;
+}

--- a/tests/end_to_end/litmus_vcall.cpp
+++ b/tests/end_to_end/litmus_vcall.cpp
@@ -1,5 +1,5 @@
 // Litmus test: Virtual call
-// Expected: BUG (entry ub.check) and vcall candidates in NIR
+// Expected: BUG and vcall candidates in NIR
 
 struct Base
 {

--- a/tests/end_to_end/litmus_vcall.cpp
+++ b/tests/end_to_end/litmus_vcall.cpp
@@ -1,0 +1,21 @@
+// Litmus test: Virtual call
+// Expected: BUG (entry ub.check) and vcall candidates in NIR
+
+struct Base
+{
+    virtual int value() { return 1; }
+    virtual ~Base() = default;
+};
+
+struct Derived : Base
+{
+    int value() override { return 2; }
+};
+
+int main()
+{
+    Base* ptr = new Derived();
+    int out = ptr->value();
+    delete ptr;
+    return out;
+}

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_litmus_e2e.cpp
- * @brief End-to-end litmus tests for div0/null/oob.
+ * @brief End-to-end litmus tests for div0, null, out-of-bounds, use-after-lifetime,
+ *        double-free, uninitialized read, exception RAII, and virtual calls.
  */
 
 #include <cctype>

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -3,11 +3,15 @@
  * @brief End-to-end litmus tests for div0/null/oob.
  */
 
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <stdexcept>
 #include <string>
+#include <unordered_set>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -57,44 +61,135 @@ void write_compile_commands(const fs::path& output,
                             const fs::path& repo_root,
                             const fs::path& source)
 {
+    std::string extension = source.extension().string();
+    for (char& ch : extension) {
+        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    }
+    const bool is_c = extension == ".c";
+    const std::string compiler = is_c ? "clang" : "clang++";
+    const std::string standard = is_c ? "-std=c11" : "-std=c++23";
+
     nlohmann::json compile_db = nlohmann::json::array();
     compile_db.push_back({
-        {"directory",                           repo_root.string()},
-        {     "file",                              source.string()},
-        {"arguments", {"clang", "-std=c11", "-c", source.string()}}
+        {"directory",                          repo_root.string()},
+        {     "file",                             source.string()},
+        {"arguments", {compiler, standard, "-c", source.string()}}
     });
 
     std::ofstream out(output);
     out << compile_db.dump(2);
 }
 
-void expect_bug_result(const fs::path& validated_results)
+struct LitmusCase
 {
-    std::ifstream in(validated_results);
-    ASSERT_TRUE(in.is_open()) << "Failed to open " << validated_results.string();
-    nlohmann::json json = nlohmann::json::parse(in);
+    std::string name;
+    fs::path source_path;
+    std::vector<std::string> expected_po_kinds;
+    std::vector<std::string> expected_categories;
+    std::vector<std::string> required_ops;
+    std::vector<std::string> required_edge_kinds;
+    bool require_vcall_candidates = false;
+};
 
-    ASSERT_TRUE(json.contains("results")) << "validated_results missing results";
-    ASSERT_TRUE(json.at("results").is_array());
-
-    bool has_bug = false;
-    for (const auto& result : json.at("results")) {
-        if (result.contains("category") && result.at("category") == "BUG") {
-            has_bug = true;
-            break;
-        }
+nlohmann::json load_json_file(const fs::path& path)
+{
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        throw std::runtime_error("Failed to open " + path.string());
     }
-    EXPECT_TRUE(has_bug) << "Expected BUG entry in validated_results";
+    return nlohmann::json::parse(in);
 }
 
-void run_litmus_case(const std::string& case_name, const fs::path& source_path)
+void expect_categories(const nlohmann::json& validated_results,
+                       const std::vector<std::string>& expected_categories)
+{
+    ASSERT_TRUE(validated_results.contains("results")) << "validated_results missing results";
+    ASSERT_TRUE(validated_results.at("results").is_array());
+
+    std::unordered_set<std::string> categories;
+    for (const auto& result : validated_results.at("results")) {
+        if (result.contains("category") && result.at("category").is_string()) {
+            categories.insert(result.at("category").get<std::string>());
+        }
+    }
+    for (const auto& category : expected_categories) {
+        EXPECT_NE(categories.find(category), categories.end())
+            << "Expected category " << category << " in validated_results";
+    }
+}
+
+void expect_po_kinds(const nlohmann::json& po_list,
+                     const std::vector<std::string>& expected_po_kinds)
+{
+    ASSERT_TRUE(po_list.contains("pos")) << "po_list missing pos";
+    ASSERT_TRUE(po_list.at("pos").is_array());
+
+    std::unordered_set<std::string> po_kinds;
+    for (const auto& po : po_list.at("pos")) {
+        if (po.contains("po_kind") && po.at("po_kind").is_string()) {
+            po_kinds.insert(po.at("po_kind").get<std::string>());
+        }
+    }
+    for (const auto& po_kind : expected_po_kinds) {
+        EXPECT_NE(po_kinds.find(po_kind), po_kinds.end())
+            << "Expected po_kind " << po_kind << " in po_list";
+    }
+}
+
+std::unordered_set<std::string> collect_ops(const nlohmann::json& nir)
+{
+    std::unordered_set<std::string> ops;
+    for (const auto& func : nir.at("functions")) {
+        for (const auto& block : func.at("cfg").at("blocks")) {
+            for (const auto& inst : block.at("insts")) {
+                ops.insert(inst.at("op").get<std::string>());
+            }
+        }
+    }
+    return ops;
+}
+
+std::unordered_set<std::string> collect_edge_kinds(const nlohmann::json& nir)
+{
+    std::unordered_set<std::string> kinds;
+    for (const auto& func : nir.at("functions")) {
+        for (const auto& edge : func.at("cfg").at("edges")) {
+            kinds.insert(edge.at("kind").get<std::string>());
+        }
+    }
+    return kinds;
+}
+
+bool has_vcall_candidates(const nlohmann::json& nir)
+{
+    bool has_vcall = false;
+    bool has_candidate_set = false;
+    for (const auto& func : nir.at("functions")) {
+        for (const auto& block : func.at("cfg").at("blocks")) {
+            for (const auto& inst : block.at("insts")) {
+                if (inst.at("op").get<std::string>() == "vcall") {
+                    has_vcall = true;
+                }
+            }
+        }
+        if (func.contains("tables") && func.at("tables").contains("vcall_candidates")) {
+            const auto& candidates = func.at("tables").at("vcall_candidates");
+            if (candidates.is_array() && !candidates.empty()) {
+                has_candidate_set = true;
+            }
+        }
+    }
+    return has_vcall && has_candidate_set;
+}
+
+void run_litmus_case(const LitmusCase& test_case)
 {
     const fs::path repo_root = SAPPP_REPO_ROOT;
     const fs::path sappp_bin = fs::path(SAPPP_BIN_DIR) / "sappp";
     const fs::path schema_dir = repo_root / "schemas";
 
-    TempDir temp_dir(std::format("sappp_e2e_{}", case_name));
-    fs::path work_dir = temp_dir.path() / case_name;
+    TempDir temp_dir(std::format("sappp_e2e_{}", test_case.name));
+    fs::path work_dir = temp_dir.path() / test_case.name;
     fs::create_directories(work_dir);
 
     fs::path compile_commands = work_dir / "compile_commands.json";
@@ -103,7 +198,7 @@ void run_litmus_case(const std::string& case_name, const fs::path& source_path)
     fs::path pack_path = work_dir / "pack.tar.gz";
     fs::path diff_path = work_dir / "diff.json";
 
-    write_compile_commands(compile_commands, repo_root, source_path);
+    write_compile_commands(compile_commands, repo_root, test_case.source_path);
 
     std::string base = std::format("cd {} && {}", quote_path(repo_root), quote_path(sappp_bin));
 
@@ -122,6 +217,31 @@ void run_litmus_case(const std::string& case_name, const fs::path& source_path)
                                           quote_path(schema_dir));
     ASSERT_EQ(run_command(analyze_cmd), 0) << analyze_cmd;
 
+    if (!test_case.expected_po_kinds.empty()) {
+        fs::path po_list = out_dir / "po" / "po_list.json";
+        ASSERT_TRUE(fs::exists(po_list)) << po_list.string();
+        expect_po_kinds(load_json_file(po_list), test_case.expected_po_kinds);
+    }
+
+    if (!test_case.required_ops.empty() || !test_case.required_edge_kinds.empty()
+        || test_case.require_vcall_candidates) {
+        fs::path nir_path = out_dir / "frontend" / "nir.json";
+        ASSERT_TRUE(fs::exists(nir_path)) << nir_path.string();
+        auto nir = load_json_file(nir_path);
+        auto ops = collect_ops(nir);
+        for (const auto& op : test_case.required_ops) {
+            EXPECT_NE(ops.find(op), ops.end()) << "Expected op " << op << " in NIR";
+        }
+        auto edge_kinds = collect_edge_kinds(nir);
+        for (const auto& edge_kind : test_case.required_edge_kinds) {
+            EXPECT_NE(edge_kinds.find(edge_kind), edge_kinds.end())
+                << "Expected edge kind " << edge_kind << " in NIR";
+        }
+        if (test_case.require_vcall_candidates) {
+            EXPECT_TRUE(has_vcall_candidates(nir)) << "Expected vcall candidates in NIR";
+        }
+    }
+
     std::string validate_cmd = std::format("{} validate --in {} --schema-dir {}",
                                            base,
                                            quote_path(out_dir),
@@ -130,7 +250,9 @@ void run_litmus_case(const std::string& case_name, const fs::path& source_path)
 
     fs::path validated_results = out_dir / "results" / "validated_results.json";
     ASSERT_TRUE(fs::exists(validated_results)) << validated_results.string();
-    expect_bug_result(validated_results);
+    if (!test_case.expected_categories.empty()) {
+        expect_categories(load_json_file(validated_results), test_case.expected_categories);
+    }
 
     std::string pack_cmd =
         std::format("{} pack --in {} --out {}", base, quote_path(out_dir), quote_path(pack_path));
@@ -150,15 +272,104 @@ void run_litmus_case(const std::string& case_name, const fs::path& source_path)
 
 TEST(LitmusE2E, Div0)
 {
-    run_litmus_case("div0", fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_div0.c");
+    run_litmus_case(LitmusCase{
+        .name = "div0",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_div0.c",
+        .expected_po_kinds = {"UB.DivZero"},
+        .expected_categories = {"BUG"},
+        .required_ops = {},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
 }
 
 TEST(LitmusE2E, NullDeref)
 {
-    run_litmus_case("null", fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_null.c");
+    run_litmus_case(LitmusCase{
+        .name = "null",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_null.c",
+        .expected_po_kinds = {"UB.NullDeref"},
+        .expected_categories = {"BUG"},
+        .required_ops = {},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
 }
 
 TEST(LitmusE2E, OutOfBounds)
 {
-    run_litmus_case("oob", fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_oob.c");
+    run_litmus_case(LitmusCase{
+        .name = "oob",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_oob.c",
+        .expected_po_kinds = {"UB.OutOfBounds"},
+        .expected_categories = {"BUG"},
+        .required_ops = {},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
+}
+
+TEST(LitmusE2E, UseAfterLifetime)
+{
+    run_litmus_case(LitmusCase{
+        .name = "use_after_lifetime",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_use_after_lifetime.cpp",
+        .expected_po_kinds = {"UseAfterLifetime"},
+        .expected_categories = {"UNKNOWN"},
+        .required_ops = {},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
+}
+
+TEST(LitmusE2E, DoubleFree)
+{
+    run_litmus_case(LitmusCase{
+        .name = "double_free",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_double_free.cpp",
+        .expected_po_kinds = {"DoubleFree"},
+        .expected_categories = {"UNKNOWN"},
+        .required_ops = {},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
+}
+
+TEST(LitmusE2E, UninitRead)
+{
+    run_litmus_case(LitmusCase{
+        .name = "uninit_read",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_uninit_read.cpp",
+        .expected_po_kinds = {"UninitRead"},
+        .expected_categories = {"UNKNOWN"},
+        .required_ops = {},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
+}
+
+TEST(LitmusE2E, ExceptionRaii)
+{
+    run_litmus_case(LitmusCase{
+        .name = "exception_raii",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_exception_raii.cpp",
+        .expected_po_kinds = {"UB.Shift"},
+        .expected_categories = {"SAFE"},
+        .required_ops = {"invoke", "throw", "landingpad", "dtor"},
+        .required_edge_kinds = {"exception"},
+        .require_vcall_candidates = false,
+    });
+}
+
+TEST(LitmusE2E, VirtualCall)
+{
+    run_litmus_case(LitmusCase{
+        .name = "vcall",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_vcall.cpp",
+        .expected_po_kinds = {},
+        .expected_categories = {"BUG"},
+        .required_ops = {"vcall"},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = true,
+    });
 }


### PR DESCRIPTION
## Summary
- add explicit sappp_sink/sappp_check markers to frontend and tests
- expand E2E litmus cases for lifetime/double-free/uninit/RAII/vcall
- extend determinism and analyzer/validator unit coverage

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure
- ctest --test-dir build -R determinism --output-on-failure
- ./scripts/agent-final-check.sh --ci

Resolves #54