### PR TITLE
UseAfterLifetimeを寿命判定でBUG/SAFE化

### DIFF
--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -357,6 +357,288 @@ struct IrAnchor
     return std::string("predicate");
 }
 
+enum class LifetimeValue {
+    kAlive,
+    kDead,
+    kMaybe,
+};
+
+struct LifetimeState
+{
+    std::map<std::string, LifetimeValue> values;
+
+    LifetimeState()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : values()
+    {}
+};
+
+[[nodiscard]] LifetimeValue merge_lifetime_value(LifetimeValue a, LifetimeValue b)
+{
+    if (a == b) {
+        return a;
+    }
+    return LifetimeValue::kMaybe;
+}
+
+[[nodiscard]] LifetimeState merge_lifetime_states(const LifetimeState& a, const LifetimeState& b)
+{
+    LifetimeState result;
+    for (const auto& [key, value] : a.values) {
+        LifetimeValue other = LifetimeValue::kMaybe;
+        auto it = b.values.find(key);
+        if (it != b.values.end()) {
+            other = it->second;
+        }
+        result.values.emplace(key, merge_lifetime_value(value, other));
+    }
+    for (const auto& [key, value] : b.values) {
+        if (result.values.contains(key)) {
+            continue;
+        }
+        result.values.emplace(key, merge_lifetime_value(LifetimeValue::kMaybe, value));
+    }
+    return result;
+}
+
+[[nodiscard]] std::optional<std::string>
+extract_first_string_arg(const nlohmann::json& inst)  // NOLINTNEXTLINE(readability-function-size)
+{
+    if (!inst.contains("args") || !inst.at("args").is_array()) {
+        return std::nullopt;
+    }
+    const auto& args = inst.at("args");
+    if (args.empty()) {
+        return std::nullopt;
+    }
+    const auto& first = args.at(0);
+    if (!first.is_string()) {
+        return std::nullopt;
+    }
+    return first.get<std::string>();
+}
+
+void apply_lifetime_effect(const nlohmann::json& inst, LifetimeState& state)
+{
+    if (!inst.contains("op") || !inst.at("op").is_string()) {
+        return;
+    }
+    const auto& op = inst.at("op").get_ref<const std::string&>();
+    auto label = extract_first_string_arg(inst);
+    if (!label.has_value()) {
+        return;
+    }
+    if (op == "lifetime.begin") {
+        state.values[*label] = LifetimeValue::kAlive;
+    } else if (op == "lifetime.end" || op == "dtor") {
+        state.values[*label] = LifetimeValue::kDead;
+    }
+}
+
+struct FunctionLifetimeAnalysis
+{
+    std::string function_uid;
+    std::string entry_block;
+    std::map<std::string, const nlohmann::json*> blocks;
+    std::vector<std::string> block_order;
+    std::map<std::string, std::vector<std::string>> predecessors;
+    std::map<std::string, LifetimeState> in_states;
+    std::map<std::string, LifetimeState> out_states;
+
+    // NOLINTBEGIN(readability-redundant-member-init) - required for -Weffc++.
+    FunctionLifetimeAnalysis()
+        : function_uid()
+        , entry_block()
+        , blocks()
+        , block_order()
+        , predecessors()
+        , in_states()
+        , out_states()
+    {}
+    // NOLINTEND(readability-redundant-member-init)
+};
+
+struct LifetimeAnalysisCache
+{
+    std::map<std::string, FunctionLifetimeAnalysis> functions;
+
+    LifetimeAnalysisCache()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : functions()
+    {}
+};
+
+[[nodiscard]] LifetimeState merge_predecessor_states(const FunctionLifetimeAnalysis& analysis,
+                                                     std::string_view block_id)
+{
+    auto pred_it = analysis.predecessors.find(std::string(block_id));
+    if (pred_it == analysis.predecessors.end() || pred_it->second.empty()) {
+        return LifetimeState{};
+    }
+
+    bool first = true;
+    LifetimeState merged;
+    for (const auto& pred : pred_it->second) {
+        auto out_it = analysis.out_states.find(pred);
+        if (out_it == analysis.out_states.end()) {
+            continue;
+        }
+        if (first) {
+            merged = out_it->second;
+            first = false;
+            continue;
+        }
+        merged = merge_lifetime_states(merged, out_it->second);
+    }
+
+    if (first) {
+        return LifetimeState{};
+    }
+    return merged;
+}
+
+[[nodiscard]] LifetimeState apply_block_transfer(const LifetimeState& in_state,
+                                                 const nlohmann::json& block)
+{
+    LifetimeState state = in_state;
+    if (!block.contains("insts") || !block.at("insts").is_array()) {
+        return state;
+    }
+    for (const auto& inst : block.at("insts")) {
+        apply_lifetime_effect(inst, state);
+    }
+    return state;
+}
+
+void compute_lifetime_fixpoint(FunctionLifetimeAnalysis& analysis)
+{
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto& block_id : analysis.block_order) {
+            LifetimeState in_state = merge_predecessor_states(analysis, block_id);
+            auto in_it = analysis.in_states.find(block_id);
+            if (in_it == analysis.in_states.end() || in_it->second.values != in_state.values) {
+                analysis.in_states[block_id] = in_state;
+                changed = true;
+            }
+
+            auto block_it = analysis.blocks.find(block_id);
+            if (block_it == analysis.blocks.end()) {
+                continue;
+            }
+            LifetimeState out_state = apply_block_transfer(in_state, *block_it->second);
+            auto out_it = analysis.out_states.find(block_id);
+            if (out_it == analysis.out_states.end() || out_it->second.values != out_state.values) {
+                analysis.out_states[block_id] = out_state;
+                changed = true;
+            }
+        }
+    }
+}
+
+[[nodiscard]] std::optional<LifetimeState> state_at_anchor(const FunctionLifetimeAnalysis& analysis,
+                                                           const IrAnchor& anchor)
+{
+    auto block_it = analysis.blocks.find(anchor.block_id);
+    if (block_it == analysis.blocks.end()) {
+        return std::nullopt;
+    }
+    auto in_it = analysis.in_states.find(anchor.block_id);
+    LifetimeState state;
+    if (in_it != analysis.in_states.end()) {
+        state = in_it->second;
+    }
+    const nlohmann::json& block = *block_it->second;
+    if (!block.contains("insts") || !block.at("insts").is_array()) {
+        return std::nullopt;
+    }
+    for (const auto& inst : block.at("insts")) {
+        if (inst.contains("id") && inst.at("id").is_string()
+            && inst.at("id").get<std::string>() == anchor.inst_id) {
+            return state;
+        }
+        apply_lifetime_effect(inst, state);
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] LifetimeAnalysisCache
+build_lifetime_analysis_cache(const nlohmann::json& nir_json)  // NOLINT(readability-function-size)
+{
+    LifetimeAnalysisCache cache;
+    if (!nir_json.contains("functions") || !nir_json.at("functions").is_array()) {
+        return cache;
+    }
+
+    for (const auto& func : nir_json.at("functions")) {
+        if (!func.is_object()) {
+            continue;
+        }
+        if (!func.contains("function_uid") || !func.at("function_uid").is_string()) {
+            continue;
+        }
+        if (!func.contains("cfg") || !func.at("cfg").is_object()) {
+            continue;
+        }
+        const auto& cfg = func.at("cfg");
+        if (!cfg.contains("blocks") || !cfg.at("blocks").is_array()) {
+            continue;
+        }
+
+        FunctionLifetimeAnalysis analysis;
+        analysis.function_uid = func.at("function_uid").get<std::string>();
+        if (cfg.contains("entry") && cfg.at("entry").is_string()) {
+            analysis.entry_block = cfg.at("entry").get<std::string>();
+        }
+
+        for (const auto& block : cfg.at("blocks")) {
+            if (!block.is_object() || !block.contains("id") || !block.at("id").is_string()) {
+                continue;
+            }
+            std::string block_id = block.at("id").get<std::string>();
+            analysis.block_order.push_back(block_id);
+            analysis.blocks.emplace(block_id, &block);
+            analysis.in_states.emplace(block_id, LifetimeState{});
+            analysis.out_states.emplace(block_id, LifetimeState{});
+        }
+
+        if (cfg.contains("edges") && cfg.at("edges").is_array()) {
+            for (const auto& edge : cfg.at("edges")) {
+                if (!edge.is_object()) {
+                    continue;
+                }
+                if (!edge.contains("from") || !edge.at("from").is_string()) {
+                    continue;
+                }
+                if (!edge.contains("to") || !edge.at("to").is_string()) {
+                    continue;
+                }
+                std::string from = edge.at("from").get<std::string>();
+                std::string to = edge.at("to").get<std::string>();
+                analysis.predecessors[to].push_back(std::move(from));
+            }
+        }
+
+        for (auto& [block_id, preds] : analysis.predecessors) {
+            (void)block_id;
+            std::ranges::stable_sort(preds);
+            auto unique_end = std::ranges::unique(preds);
+            preds.erase(unique_end.begin(), unique_end.end());
+        }
+
+        if (!analysis.block_order.empty()) {
+            if (analysis.entry_block.empty()) {
+                analysis.entry_block = analysis.block_order.front();
+            }
+            compute_lifetime_fixpoint(analysis);
+            cache.functions.emplace(analysis.function_uid, std::move(analysis));
+        }
+    }
+
+    return cache;
+}
+
 [[nodiscard]] nlohmann::json
 make_ir_ref_obj(const std::string& tu_id, const std::string& function_uid, const IrAnchor& anchor)
 {
@@ -668,6 +950,16 @@ struct UnknownDetails
                           .refinement_domain = "unknown"};
 }
 
+[[nodiscard]] UnknownDetails build_use_after_lifetime_unknown_details(std::string_view notes)
+{
+    return UnknownDetails{.code = "LifetimeStateUnknown",
+                          .missing_notes = std::string(notes),
+                          .refinement_message =
+                              "Provide lifetime target context or refine lifetime tracking.",
+                          .refinement_action = "refine-lifetime",
+                          .refinement_domain = "lifetime"};
+}
+
 [[nodiscard]] sappp::Result<nlohmann::json>
 build_unknown_entry(const nlohmann::json& po,
                     std::string_view po_id,
@@ -779,6 +1071,7 @@ struct PoProcessingContext
     const std::unordered_map<std::string, std::string>* function_uid_map = nullptr;
     const ContractIndex* contract_index = nullptr;
     std::unordered_map<std::string, std::string>* contract_ref_cache = nullptr;
+    const LifetimeAnalysisCache* lifetime_cache = nullptr;
     std::string_view tu_id;
     const sappp::VersionTriple* versions = nullptr;
 };
@@ -985,7 +1278,106 @@ extract_predicate_boolean(const nlohmann::json& predicate_expr)
     return std::optional<bool>();
 }
 
-[[nodiscard]] sappp::Result<PoDecision> decide_po(const nlohmann::json& po)
+[[nodiscard]] std::optional<std::string>
+extract_lifetime_target(const nlohmann::json& predicate_expr)
+{
+    if (!predicate_expr.contains("op") || !predicate_expr.at("op").is_string()) {
+        return std::nullopt;
+    }
+    if (!predicate_expr.contains("args") || !predicate_expr.at("args").is_array()) {
+        return std::nullopt;
+    }
+    const auto& args = predicate_expr.at("args");
+    const auto& op = predicate_expr.at("op").get_ref<const std::string&>();
+    if (op == "sink.marker") {
+        if (args.size() >= 2 && args.at(1).is_string()) {
+            return args.at(1).get<std::string>();
+        }
+        return std::nullopt;
+    }
+    if ((op == "lifetime.begin" || op == "lifetime.end") && args.size() == 1
+        && args.at(0).is_string()) {
+        return args.at(0).get<std::string>();
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] sappp::Result<PoDecision>
+decide_use_after_lifetime(  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    const nlohmann::json& po,
+    const nlohmann::json& predicate_expr,
+    const PoProcessingContext& context)
+{
+    PoDecision decision;
+    auto target = extract_lifetime_target(predicate_expr);
+    if (!target) {
+        decision.is_unknown = true;
+        decision.unknown_details = build_use_after_lifetime_unknown_details(
+            "Lifetime target is missing from the PO predicate.");
+        return decision;
+    }
+    if (context.lifetime_cache == nullptr || context.function_uid_map == nullptr) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime analysis context unavailable.");
+        return decision;
+    }
+
+    auto function_uid = resolve_function_uid(*context.function_uid_map, po);
+    if (!function_uid) {
+        return std::unexpected(function_uid.error());
+    }
+    auto anchor = extract_anchor(po);
+    if (!anchor) {
+        return std::unexpected(anchor.error());
+    }
+
+    auto analysis_it = context.lifetime_cache->functions.find(*function_uid);
+    if (analysis_it == context.lifetime_cache->functions.end()) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime analysis missing for function.");
+        return decision;
+    }
+
+    auto state = state_at_anchor(analysis_it->second, *anchor);
+    if (!state) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime analysis missing at anchor.");
+        return decision;
+    }
+
+    auto state_it = state->values.find(*target);
+    if (state_it == state->values.end()) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime target is not tracked at anchor.");
+        return decision;
+    }
+
+    switch (state_it->second) {
+        case LifetimeValue::kDead:
+            decision.is_bug = true;
+            return decision;
+        case LifetimeValue::kAlive:
+            decision.is_safe = true;
+            return decision;
+        case LifetimeValue::kMaybe:
+            decision.is_unknown = true;
+            decision.unknown_details = build_use_after_lifetime_unknown_details(
+                "Lifetime state is indeterminate at this point.");
+            return decision;
+        default:
+            decision.is_unknown = true;
+            decision.unknown_details =
+                build_use_after_lifetime_unknown_details("Lifetime state is indeterminate.");
+            return decision;
+    }
+}
+
+[[nodiscard]] sappp::Result<PoDecision> decide_po(const nlohmann::json& po,
+                                                  const PoProcessingContext& context)
 {
     auto po_kind = require_string(JsonFieldContext{.obj = &po, .key = "po_kind", .context = "po"});
     if (!po_kind) {
@@ -1019,6 +1411,14 @@ extract_predicate_boolean(const nlohmann::json& predicate_expr)
         return decision;
     }
 
+    if (*po_kind == "UseAfterLifetime") {
+        auto decision = decide_use_after_lifetime(po, *predicate_expr, context);
+        if (!decision) {
+            return std::unexpected(decision.error());
+        }
+        return *decision;
+    }
+
     if (op == "sink.marker") {
         if (*po_kind == "UB.OutOfBounds" || *po_kind == "UB.NullDeref") {
             PoDecision decision;
@@ -1046,7 +1446,7 @@ resolve_contracts(const nlohmann::json& po, const PoProcessingContext& context)
 [[nodiscard]] sappp::Result<PoProcessingOutput> process_po(const nlohmann::json& po,
                                                            PoProcessingContext& context)
 {
-    auto decision = decide_po(po);
+    auto decision = decide_po(po, context);
     if (!decision) {
         return std::unexpected(decision.error());
     }
@@ -1164,6 +1564,7 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
     if (!contract_index) {
         return std::unexpected(contract_index.error());
     }
+    const auto lifetime_cache = build_lifetime_analysis_cache(nir_json);
     std::unordered_map<std::string, std::string> contract_ref_cache;
 
     std::vector<nlohmann::json> unknowns;
@@ -1173,6 +1574,7 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
                                 .function_uid_map = &function_uid_map,
                                 .contract_index = &(*contract_index),
                                 .contract_ref_cache = &contract_ref_cache,
+                                .lifetime_cache = &lifetime_cache,
                                 .tu_id = *tu_id,
                                 .versions = &m_config.versions};
 

--- a/libs/frontend_clang/frontend.cpp
+++ b/libs/frontend_clang/frontend.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <clang/AST/ASTConsumer.h>
@@ -345,6 +346,32 @@ std::optional<std::string> extract_string_literal(const clang::Expr* expr)
     return literal->getString().str();
 }
 
+std::optional<std::string> extract_decl_ref_name(const clang::Expr* expr)
+{
+    const auto* stripped = strip_parens(expr);
+    if (const auto* decl_ref = clang::dyn_cast_or_null<clang::DeclRefExpr>(stripped)) {
+        const auto* decl = decl_ref->getDecl();
+        if (decl != nullptr && !decl->getName().empty()) {
+            return decl->getName().str();
+        }
+    }
+    if (const auto* member = clang::dyn_cast_or_null<clang::MemberExpr>(stripped)) {
+        const auto* member_decl = member->getMemberDecl();
+        if (member_decl != nullptr && !member_decl->getName().empty()) {
+            return member_decl->getName().str();
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> extract_sink_target_label(const clang::Expr* expr)
+{
+    if (auto literal = extract_string_literal(expr)) {
+        return literal;
+    }
+    return extract_decl_ref_name(expr);
+}
+
 std::optional<bool> extract_bool_literal(const clang::Expr* expr)
 {
     const auto* stripped = strip_parens(expr);
@@ -382,6 +409,12 @@ struct ClassifiedStmt
 {
     std::string op;
     std::vector<nlohmann::json> args;
+};
+
+struct SinkMarker
+{
+    std::string kind;
+    std::optional<std::string> target;
 };
 
 std::optional<ClassifiedStmt> classify_return_stmt(const clang::Stmt* stmt)
@@ -509,9 +542,9 @@ ClassifiedStmt classify_stmt(const clang::Stmt* stmt)
  * this function is to provide a simple, conservative starting point rather
  * than a precise classification of UB.
  */
-std::vector<std::string> detect_sink_markers(const clang::Stmt* stmt)
+std::vector<SinkMarker> detect_sink_markers(const clang::Stmt* stmt)
 {
-    std::vector<std::string> markers;
+    std::vector<SinkMarker> markers;
     if (stmt == nullptr) {
         return markers;
     }
@@ -526,23 +559,28 @@ std::vector<std::string> detect_sink_markers(const clang::Stmt* stmt)
             const auto opcode = bin_op->getOpcode();
             if (opcode == clang::BO_Div || opcode == clang::BO_Rem || opcode == clang::BO_DivAssign
                 || opcode == clang::BO_RemAssign) {
-                markers.emplace_back("div0");
+                markers.push_back(SinkMarker{.kind = "div0", .target = std::nullopt});
             }
         } else if (const auto* call_expr = clang::dyn_cast<clang::CallExpr>(current)) {
             const auto* callee = call_expr->getDirectCallee();
             if (callee != nullptr && callee->getNameAsString() == "sappp_sink") {
                 if (call_expr->getNumArgs() > 0) {
                     if (auto kind = extract_string_literal(call_expr->getArg(0))) {
-                        markers.push_back(*kind);
+                        std::optional<std::string> target;
+                        if (call_expr->getNumArgs() > 1) {
+                            target = extract_sink_target_label(call_expr->getArg(1));
+                        }
+                        markers.push_back(
+                            SinkMarker{.kind = std::move(*kind), .target = std::move(target)});
                     }
                 }
             }
         } else if (const auto* unary_op = clang::dyn_cast<clang::UnaryOperator>(current)) {
             if (unary_op->getOpcode() == clang::UO_Deref) {
-                markers.emplace_back("null");
+                markers.push_back(SinkMarker{.kind = "null", .target = std::nullopt});
             }
         } else if (clang::isa<clang::ArraySubscriptExpr>(current)) {
-            markers.emplace_back("oob");
+            markers.push_back(SinkMarker{.kind = "oob", .target = std::nullopt});
         }
 
         for (const auto* child : current->children()) {
@@ -552,8 +590,17 @@ std::vector<std::string> detect_sink_markers(const clang::Stmt* stmt)
         }
     }
 
-    std::ranges::sort(markers);
-    auto unique_end = std::ranges::unique(markers);
+    std::ranges::sort(markers, [](const SinkMarker& a, const SinkMarker& b) {
+        if (a.kind != b.kind) {
+            return a.kind < b.kind;
+        }
+        const auto a_key = std::make_pair(a.target.has_value(), a.target.value_or(""));
+        const auto b_key = std::make_pair(b.target.has_value(), b.target.value_or(""));
+        return a_key < b_key;
+    });
+    auto unique_end = std::ranges::unique(markers, [](const SinkMarker& a, const SinkMarker& b) {
+        return a.kind == b.kind && a.target == b.target;
+    });
     markers.erase(unique_end.begin(), markers.end());
     return markers;
 }
@@ -864,11 +911,14 @@ void append_cfg_stmt_element(const clang::CFGStmt& stmt_elem,
                            std::move(*vcall_inst),
                            *context.source_entries);
         append_ctor_instructions_for_stmt(stmt, context, inst_index);
-        for (const auto& sink_kind : detect_sink_markers(stmt)) {
+        for (const auto& marker : detect_sink_markers(stmt)) {
             ir::Instruction sink_inst;
             sink_inst.id = "I" + std::to_string(inst_index++);
             sink_inst.op = "sink.marker";
-            sink_inst.args = {nlohmann::json(sink_kind)};
+            sink_inst.args = {nlohmann::json(marker.kind)};
+            if (marker.target.has_value()) {
+                sink_inst.args.push_back(nlohmann::json(*marker.target));
+            }
             sink_inst.src = make_location(
                 {.source_manager = context.source_manager,
                  .loc = stmt != nullptr ? stmt->getBeginLoc() : clang::SourceLocation()});
@@ -893,11 +943,14 @@ void append_cfg_stmt_element(const clang::CFGStmt& stmt_elem,
                        std::move(inst),
                        *context.source_entries);
     append_ctor_instructions_for_stmt(stmt, context, inst_index);
-    for (const auto& sink_kind : detect_sink_markers(stmt)) {
+    for (const auto& marker : detect_sink_markers(stmt)) {
         ir::Instruction sink_inst;
         sink_inst.id = "I" + std::to_string(inst_index++);
         sink_inst.op = "sink.marker";
-        sink_inst.args = {nlohmann::json(sink_kind)};
+        sink_inst.args = {nlohmann::json(marker.kind)};
+        if (marker.target.has_value()) {
+            sink_inst.args.push_back(nlohmann::json(*marker.target));
+        }
         sink_inst.src =
             make_location({.source_manager = context.source_manager, .loc = stmt->getBeginLoc()});
         append_instruction(*context.nir_block,

--- a/tests/determinism/test_e2e_determinism.cpp
+++ b/tests/determinism/test_e2e_determinism.cpp
@@ -109,7 +109,7 @@ private:
     std::ofstream out(source_path);
     out << R"(#include <cstddef>
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, const char* target = nullptr);
 void sappp_check(const char* kind, bool predicate);
 
 struct Guard {
@@ -137,7 +137,7 @@ int use_after_lifetime() {
         int use_after_lifetime = 7;
         ptr = &use_after_lifetime;
     }
-    sappp_sink("use-after-lifetime");
+    sappp_sink("use-after-lifetime", "use_after_lifetime");
     return *ptr;
 }
 

--- a/tests/end_to_end/litmus_use_after_lifetime.cpp
+++ b/tests/end_to_end/litmus_use_after_lifetime.cpp
@@ -1,7 +1,7 @@
 // Litmus test: Use-after-lifetime
-// Expected: UNKNOWN (UseAfterLifetime)
+// Expected: BUG (UseAfterLifetime)
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, const char* target);
 
 int main()
 {
@@ -10,6 +10,6 @@ int main()
         int use_after_lifetime = 42;
         ptr = &use_after_lifetime;
     }
-    sappp_sink("use-after-lifetime");
+    sappp_sink("use-after-lifetime", "use_after_lifetime");
     return *ptr;
 }

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -315,7 +315,7 @@ TEST(LitmusE2E, UseAfterLifetime)
         .name = "use_after_lifetime",
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_use_after_lifetime.cpp",
         .expected_po_kinds = {"UseAfterLifetime"},
-        .expected_categories = {"UNKNOWN"},
+        .expected_categories = {"BUG"},
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,


### PR DESCRIPTION
## Summary\n- Lifetimeドメインを追加してUseAfterLifetimeをBUG/SAFE判定\n- sappp_sinkの対象文字列をIRへ伝播\n- UseAfterLifetime litmus/テスト期待値を更新\n\n## Testing\n- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON\n- cmake --build build --parallel\n- ctest --test-dir build --output-on-failure\n- ctest --test-dir build -R determinism --output-on-failure\n- cmake -S . -B build-frontend-gcc -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14\n- cmake --build build-frontend-gcc --parallel\n- ctest --test-dir build-frontend-gcc --output-on-failure\n- ctest --test-dir build-frontend-gcc -R determinism --output-on-failure\n- ./scripts/agent-final-check.sh --until-ok