### PR TITLE
Issue #67: new/delete IRイベントと解放判定

### DIFF
--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -358,6 +358,288 @@ struct IrAnchor
     return std::string("predicate");
 }
 
+enum class LifetimeValue {
+    kAlive,
+    kDead,
+    kMaybe,
+};
+
+struct LifetimeState
+{
+    std::map<std::string, LifetimeValue> values;
+
+    LifetimeState()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : values()
+    {}
+};
+
+[[nodiscard]] LifetimeValue merge_lifetime_value(LifetimeValue a, LifetimeValue b)
+{
+    if (a == b) {
+        return a;
+    }
+    return LifetimeValue::kMaybe;
+}
+
+[[nodiscard]] LifetimeState merge_lifetime_states(const LifetimeState& a, const LifetimeState& b)
+{
+    LifetimeState result;
+    for (const auto& [key, value] : a.values) {
+        LifetimeValue other = LifetimeValue::kMaybe;
+        auto it = b.values.find(key);
+        if (it != b.values.end()) {
+            other = it->second;
+        }
+        result.values.emplace(key, merge_lifetime_value(value, other));
+    }
+    for (const auto& [key, value] : b.values) {
+        if (result.values.contains(key)) {
+            continue;
+        }
+        result.values.emplace(key, merge_lifetime_value(LifetimeValue::kMaybe, value));
+    }
+    return result;
+}
+
+[[nodiscard]] std::optional<std::string>
+extract_first_string_arg(const nlohmann::json& inst)  // NOLINTNEXTLINE(readability-function-size)
+{
+    if (!inst.contains("args") || !inst.at("args").is_array()) {
+        return std::nullopt;
+    }
+    const auto& args = inst.at("args");
+    if (args.empty()) {
+        return std::nullopt;
+    }
+    const auto& first = args.at(0);
+    if (!first.is_string()) {
+        return std::nullopt;
+    }
+    return first.get<std::string>();
+}
+
+void apply_lifetime_effect(const nlohmann::json& inst, LifetimeState& state)
+{
+    if (!inst.contains("op") || !inst.at("op").is_string()) {
+        return;
+    }
+    const auto& op = inst.at("op").get_ref<const std::string&>();
+    auto label = extract_first_string_arg(inst);
+    if (!label.has_value()) {
+        return;
+    }
+    if (op == "lifetime.begin") {
+        state.values[*label] = LifetimeValue::kAlive;
+    } else if (op == "lifetime.end" || op == "dtor") {
+        state.values[*label] = LifetimeValue::kDead;
+    }
+}
+
+struct FunctionLifetimeAnalysis
+{
+    std::string function_uid;
+    std::string entry_block;
+    std::map<std::string, const nlohmann::json*> blocks;
+    std::vector<std::string> block_order;
+    std::map<std::string, std::vector<std::string>> predecessors;
+    std::map<std::string, LifetimeState> in_states;
+    std::map<std::string, LifetimeState> out_states;
+
+    // NOLINTBEGIN(readability-redundant-member-init) - required for -Weffc++.
+    FunctionLifetimeAnalysis()
+        : function_uid()
+        , entry_block()
+        , blocks()
+        , block_order()
+        , predecessors()
+        , in_states()
+        , out_states()
+    {}
+    // NOLINTEND(readability-redundant-member-init)
+};
+
+struct LifetimeAnalysisCache
+{
+    std::map<std::string, FunctionLifetimeAnalysis> functions;
+
+    LifetimeAnalysisCache()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : functions()
+    {}
+};
+
+[[nodiscard]] LifetimeState merge_predecessor_states(const FunctionLifetimeAnalysis& analysis,
+                                                     std::string_view block_id)
+{
+    auto pred_it = analysis.predecessors.find(std::string(block_id));
+    if (pred_it == analysis.predecessors.end() || pred_it->second.empty()) {
+        return LifetimeState{};
+    }
+
+    bool first = true;
+    LifetimeState merged;
+    for (const auto& pred : pred_it->second) {
+        auto out_it = analysis.out_states.find(pred);
+        if (out_it == analysis.out_states.end()) {
+            continue;
+        }
+        if (first) {
+            merged = out_it->second;
+            first = false;
+            continue;
+        }
+        merged = merge_lifetime_states(merged, out_it->second);
+    }
+
+    if (first) {
+        return LifetimeState{};
+    }
+    return merged;
+}
+
+[[nodiscard]] LifetimeState apply_block_transfer(const LifetimeState& in_state,
+                                                 const nlohmann::json& block)
+{
+    LifetimeState state = in_state;
+    if (!block.contains("insts") || !block.at("insts").is_array()) {
+        return state;
+    }
+    for (const auto& inst : block.at("insts")) {
+        apply_lifetime_effect(inst, state);
+    }
+    return state;
+}
+
+void compute_lifetime_fixpoint(FunctionLifetimeAnalysis& analysis)
+{
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto& block_id : analysis.block_order) {
+            LifetimeState in_state = merge_predecessor_states(analysis, block_id);
+            auto in_it = analysis.in_states.find(block_id);
+            if (in_it == analysis.in_states.end() || in_it->second.values != in_state.values) {
+                analysis.in_states[block_id] = in_state;
+                changed = true;
+            }
+
+            auto block_it = analysis.blocks.find(block_id);
+            if (block_it == analysis.blocks.end()) {
+                continue;
+            }
+            LifetimeState out_state = apply_block_transfer(in_state, *block_it->second);
+            auto out_it = analysis.out_states.find(block_id);
+            if (out_it == analysis.out_states.end() || out_it->second.values != out_state.values) {
+                analysis.out_states[block_id] = out_state;
+                changed = true;
+            }
+        }
+    }
+}
+
+[[nodiscard]] std::optional<LifetimeState> state_at_anchor(const FunctionLifetimeAnalysis& analysis,
+                                                           const IrAnchor& anchor)
+{
+    auto block_it = analysis.blocks.find(anchor.block_id);
+    if (block_it == analysis.blocks.end()) {
+        return std::nullopt;
+    }
+    auto in_it = analysis.in_states.find(anchor.block_id);
+    LifetimeState state;
+    if (in_it != analysis.in_states.end()) {
+        state = in_it->second;
+    }
+    const nlohmann::json& block = *block_it->second;
+    if (!block.contains("insts") || !block.at("insts").is_array()) {
+        return std::nullopt;
+    }
+    for (const auto& inst : block.at("insts")) {
+        if (inst.contains("id") && inst.at("id").is_string()
+            && inst.at("id").get<std::string>() == anchor.inst_id) {
+            return state;
+        }
+        apply_lifetime_effect(inst, state);
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] LifetimeAnalysisCache
+build_lifetime_analysis_cache(const nlohmann::json& nir_json)  // NOLINT(readability-function-size)
+{
+    LifetimeAnalysisCache cache;
+    if (!nir_json.contains("functions") || !nir_json.at("functions").is_array()) {
+        return cache;
+    }
+
+    for (const auto& func : nir_json.at("functions")) {
+        if (!func.is_object()) {
+            continue;
+        }
+        if (!func.contains("function_uid") || !func.at("function_uid").is_string()) {
+            continue;
+        }
+        if (!func.contains("cfg") || !func.at("cfg").is_object()) {
+            continue;
+        }
+        const auto& cfg = func.at("cfg");
+        if (!cfg.contains("blocks") || !cfg.at("blocks").is_array()) {
+            continue;
+        }
+
+        FunctionLifetimeAnalysis analysis;
+        analysis.function_uid = func.at("function_uid").get<std::string>();
+        if (cfg.contains("entry") && cfg.at("entry").is_string()) {
+            analysis.entry_block = cfg.at("entry").get<std::string>();
+        }
+
+        for (const auto& block : cfg.at("blocks")) {
+            if (!block.is_object() || !block.contains("id") || !block.at("id").is_string()) {
+                continue;
+            }
+            std::string block_id = block.at("id").get<std::string>();
+            analysis.block_order.push_back(block_id);
+            analysis.blocks.emplace(block_id, &block);
+            analysis.in_states.emplace(block_id, LifetimeState{});
+            analysis.out_states.emplace(block_id, LifetimeState{});
+        }
+
+        if (cfg.contains("edges") && cfg.at("edges").is_array()) {
+            for (const auto& edge : cfg.at("edges")) {
+                if (!edge.is_object()) {
+                    continue;
+                }
+                if (!edge.contains("from") || !edge.at("from").is_string()) {
+                    continue;
+                }
+                if (!edge.contains("to") || !edge.at("to").is_string()) {
+                    continue;
+                }
+                std::string from = edge.at("from").get<std::string>();
+                std::string to = edge.at("to").get<std::string>();
+                analysis.predecessors[to].push_back(std::move(from));
+            }
+        }
+
+        for (auto& [block_id, preds] : analysis.predecessors) {
+            (void)block_id;
+            std::ranges::stable_sort(preds);
+            auto unique_end = std::ranges::unique(preds);
+            preds.erase(unique_end.begin(), unique_end.end());
+        }
+
+        if (!analysis.block_order.empty()) {
+            if (analysis.entry_block.empty()) {
+                analysis.entry_block = analysis.block_order.front();
+            }
+            compute_lifetime_fixpoint(analysis);
+            cache.functions.emplace(analysis.function_uid, std::move(analysis));
+        }
+    }
+
+    return cache;
+}
+
 [[nodiscard]] nlohmann::json
 make_ir_ref_obj(const std::string& tu_id, const std::string& function_uid, const IrAnchor& anchor)
 {
@@ -871,6 +1153,16 @@ build_lifetime_summary_map(const nlohmann::json& nir_json)
                           .refinement_domain = "unknown"};
 }
 
+[[nodiscard]] UnknownDetails build_use_after_lifetime_unknown_details(std::string_view notes)
+{
+    return UnknownDetails{.code = "LifetimeStateUnknown",
+                          .missing_notes = std::string(notes),
+                          .refinement_message =
+                              "Provide lifetime target context or refine lifetime tracking.",
+                          .refinement_action = "refine-lifetime",
+                          .refinement_domain = "lifetime"};
+}
+
 [[nodiscard]] sappp::Result<nlohmann::json>
 build_unknown_entry(const nlohmann::json& po,
                     std::string_view po_id,
@@ -983,6 +1275,7 @@ struct PoProcessingContext
     const ContractIndex* contract_index = nullptr;
     std::unordered_map<std::string, std::string>* contract_ref_cache = nullptr;
     const LifetimeSummaryMap* lifetime_summaries = nullptr;
+    const LifetimeAnalysisCache* lifetime_cache = nullptr;
     std::string_view tu_id;
     const sappp::VersionTriple* versions = nullptr;
 };
@@ -1189,6 +1482,104 @@ extract_predicate_boolean(const nlohmann::json& predicate_expr)
     return std::optional<bool>();
 }
 
+[[nodiscard]] std::optional<std::string>
+extract_lifetime_target(const nlohmann::json& predicate_expr)
+{
+    if (!predicate_expr.contains("op") || !predicate_expr.at("op").is_string()) {
+        return std::nullopt;
+    }
+    if (!predicate_expr.contains("args") || !predicate_expr.at("args").is_array()) {
+        return std::nullopt;
+    }
+    const auto& args = predicate_expr.at("args");
+    const auto& op = predicate_expr.at("op").get_ref<const std::string&>();
+    if (op == "sink.marker") {
+        if (args.size() >= 2 && args.at(1).is_string()) {
+            return args.at(1).get<std::string>();
+        }
+        return std::nullopt;
+    }
+    if ((op == "lifetime.begin" || op == "lifetime.end") && args.size() == 1
+        && args.at(0).is_string()) {
+        return args.at(0).get<std::string>();
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] sappp::Result<PoDecision>
+decide_use_after_lifetime(  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    const nlohmann::json& po,
+    const nlohmann::json& predicate_expr,
+    const PoProcessingContext& context)
+{
+    PoDecision decision;
+    auto target = extract_lifetime_target(predicate_expr);
+    if (!target) {
+        decision.is_unknown = true;
+        decision.unknown_details = build_use_after_lifetime_unknown_details(
+            "Lifetime target is missing from the PO predicate.");
+        return decision;
+    }
+    if (context.lifetime_cache == nullptr || context.function_uid_map == nullptr) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime analysis context unavailable.");
+        return decision;
+    }
+
+    auto function_uid = resolve_function_uid(*context.function_uid_map, po);
+    if (!function_uid) {
+        return std::unexpected(function_uid.error());
+    }
+    auto anchor = extract_anchor(po);
+    if (!anchor) {
+        return std::unexpected(anchor.error());
+    }
+
+    auto analysis_it = context.lifetime_cache->functions.find(*function_uid);
+    if (analysis_it == context.lifetime_cache->functions.end()) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime analysis missing for function.");
+        return decision;
+    }
+
+    auto state = state_at_anchor(analysis_it->second, *anchor);
+    if (!state) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime analysis missing at anchor.");
+        return decision;
+    }
+
+    auto state_it = state->values.find(*target);
+    if (state_it == state->values.end()) {
+        decision.is_unknown = true;
+        decision.unknown_details =
+            build_use_after_lifetime_unknown_details("Lifetime target is not tracked at anchor.");
+        return decision;
+    }
+
+    switch (state_it->second) {
+        case LifetimeValue::kDead:
+            decision.is_bug = true;
+            return decision;
+        case LifetimeValue::kAlive:
+            decision.is_safe = true;
+            return decision;
+        case LifetimeValue::kMaybe:
+            decision.is_unknown = true;
+            decision.unknown_details = build_use_after_lifetime_unknown_details(
+                "Lifetime state is indeterminate at this point.");
+            return decision;
+        default:
+            decision.is_unknown = true;
+            decision.unknown_details =
+                build_use_after_lifetime_unknown_details("Lifetime state is indeterminate.");
+            return decision;
+    }
+}
+
 [[nodiscard]] sappp::Result<PoDecision> decide_po(const nlohmann::json& po,
                                                   const PoProcessingContext& context)
 {
@@ -1261,6 +1652,14 @@ extract_predicate_boolean(const nlohmann::json& predicate_expr)
         PoDecision decision;
         decision.is_bug = true;
         return decision;
+    }
+
+    if (*po_kind == "UseAfterLifetime") {
+        auto decision = decide_use_after_lifetime(po, *predicate_expr, context);
+        if (!decision) {
+            return std::unexpected(decision.error());
+        }
+        return *decision;
     }
 
     if (op == "sink.marker") {
@@ -1381,6 +1780,7 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
     if (!lifetime_summaries) {
         return std::unexpected(lifetime_summaries.error());
     }
+    const auto lifetime_cache = build_lifetime_analysis_cache(nir_json);
     std::unordered_map<std::string, std::string> contract_ref_cache;
 
     std::vector<nlohmann::json> unknowns;
@@ -1391,6 +1791,7 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
                                 .contract_index = &(*contract_index),
                                 .contract_ref_cache = &contract_ref_cache,
                                 .lifetime_summaries = &(*lifetime_summaries),
+                                .lifetime_cache = &lifetime_cache,
                                 .tu_id = *tu_id,
                                 .versions = &m_config.versions};
 

--- a/libs/validator/validator.cpp
+++ b/libs/validator/validator.cpp
@@ -1336,11 +1336,11 @@ ValidationError rule_violation_error(const std::string& message)
 
 [[nodiscard]] bool is_supported_bug_trace_op(std::string_view op)
 {
-    constexpr std::array<std::string_view, 19> kSupportedOps{
+    constexpr std::array<std::string_view, 21> kSupportedOps{
         {
-         "assign",         "branch",       "call",  "ctor",     "dtor",  "invoke", "landingpad",
-         "lifetime.begin", "lifetime.end", "load",  "move",     "ret",   "resume", "sink.marker",
-         "stmt",           "store",        "throw", "ub.check", "vcall",
+         "alloc",  "assign",      "branch",         "call",         "ctor",  "dtor",     "free",
+         "invoke", "landingpad",  "lifetime.begin", "lifetime.end", "load",  "move",     "ret",
+         "resume", "sink.marker", "stmt",           "store",        "throw", "ub.check", "vcall",
          }
     };
     return std::ranges::find(kSupportedOps, op) != kSupportedOps.end();

--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -56,6 +56,43 @@ nlohmann::json make_nir_with_insts(const nlohmann::json& insts)
     };
 }
 
+nlohmann::json make_nir_with_lifetime()
+{
+    nlohmann::json block = {
+        {   "id",                                                    "B1"       },
+        {"insts",
+         nlohmann::json::array(
+         {nlohmann::json{{"id", "I0"},
+         {"op", "lifetime.begin"},
+         {"args", nlohmann::json::array({"use_after_lifetime"})}},
+         nlohmann::json{{"id", "I1"},
+         {"op", "lifetime.end"},
+         {"args", nlohmann::json::array({"use_after_lifetime"})}},
+         nlohmann::json{
+         {"id", "I2"},
+         {"op", "sink.marker"},
+         {"args",
+         nlohmann::json::array({"use-after-lifetime", "use_after_lifetime"})}}})}
+    };
+
+    nlohmann::json func = {
+        {"function_uid","usr::foo"                        },
+        {"mangled_name",            "_Z3foov"},
+        {         "cfg",
+         {{"entry", "B1"},
+         {"blocks", nlohmann::json::array({block})},
+         {"edges", nlohmann::json::array()}} }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                "nir.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {     "functions",                           nlohmann::json::array({func})}
+    };
+}
+
 nlohmann::json make_po_list(std::string_view po_kind)
 {
     nlohmann::json po = {
@@ -102,6 +139,36 @@ make_sink_po_list(std::string_view po_kind, std::string_view block_id, std::stri
         {              "anchor",
          nlohmann::json{{"block_id", std::string(block_id)}, {"inst_id", std::string(inst_id)}}},
         {           "predicate",   nlohmann::json{{"expr", predicate_expr}, {"pretty", "sink"}}}
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                 "po.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {           "pos",                             nlohmann::json::array({po})}
+    };
+}
+
+nlohmann::json make_use_after_lifetime_po_list()
+{
+    nlohmann::json po = {
+        {               "po_id",            make_sha256('b')                                },
+        {             "po_kind",                                          "UseAfterLifetime"},
+        {     "profile_version",                                            "safety.core.v1"},
+        {   "semantics_version",                                                    "sem.v1"},
+        {"proof_system_version",                                                  "proof.v1"},
+        {       "repo_identity",
+         nlohmann::json{{"path", "src/main.cpp"}, {"content_sha256", make_sha256('c')}}     },
+        {            "function", nlohmann::json{{"usr", "usr::foo"}, {"mangled", "_Z3foov"}}},
+        {              "anchor",       nlohmann::json{{"block_id", "B1"}, {"inst_id", "I2"}}},
+        {           "predicate",
+         nlohmann::json{
+         {"expr",
+         nlohmann::json{
+         {"op", "sink.marker"},
+         {"args", nlohmann::json::array({"UseAfterLifetime", "use_after_lifetime"})}}},
+         {"pretty", "use_after_lifetime"}}                                                  }
     };
 
     return nlohmann::json{
@@ -216,7 +283,7 @@ TEST(AnalyzerContractTest, MissingContractProducesUnknownCode)
     EXPECT_FALSE(unknowns.at(0).contains("depends_on"));
 }
 
-TEST(AnalyzerContractTest, LifetimePoProducesLifetimeUnknown)
+TEST(AnalyzerContractTest, UseAfterLifetimeProducesBug)
 {
     auto temp_dir = ensure_temp_dir("sappp_analyzer_lifetime_unknown");
     auto cert_dir = temp_dir / "certstore";
@@ -229,16 +296,22 @@ TEST(AnalyzerContractTest, LifetimePoProducesLifetimeUnknown)
                      .profile = "safety.core.v1"}
     });
 
-    auto nir = make_nir();
-    auto po_list = make_po_list("UseAfterLifetime");
+    auto nir = make_nir_with_lifetime();
+    auto po_list = make_use_after_lifetime_po_list();
     auto specdb_snapshot = make_contract_snapshot(true);
 
     auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
     ASSERT_TRUE(output);
 
-    const auto& unknowns = output->unknown_ledger.at("unknowns");
-    ASSERT_EQ(unknowns.size(), 1U);
-    EXPECT_EQ(unknowns.at(0).at("unknown_code"), "LifetimeUnmodeled");
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    EXPECT_EQ(root_cert->at("result"), "BUG");
 }
 
 TEST(AnalyzerContractTest, DoubleFreePoProducesBug)

--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -38,6 +38,24 @@ nlohmann::json make_nir()
     };
 }
 
+nlohmann::json make_nir_with_insts(const nlohmann::json& insts)
+{
+    return nlohmann::json{
+        {"schema_version",                      "nir.v1"                          },
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {     "functions",
+         nlohmann::json::array({nlohmann::json{
+         {"function_uid", "usr::foo"},
+         {"mangled_name", "_Z3foov"},
+         {"cfg",
+         {{"entry", "B1"},
+         {"blocks", nlohmann::json::array({{{"id", "B1"}, {"insts", insts}}})},
+         {"edges", nlohmann::json::array()}}}}})                                  }
+    };
+}
+
 nlohmann::json make_po_list(std::string_view po_kind)
 {
     nlohmann::json po = {
@@ -54,6 +72,36 @@ nlohmann::json make_po_list(std::string_view po_kind)
          nlohmann::json{
          {"expr", nlohmann::json{{"op", "custom.op"}, {"args", nlohmann::json::array({true})}}},
          {"pretty", "custom"}}                                                              }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                 "po.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {           "pos",                             nlohmann::json::array({po})}
+    };
+}
+
+nlohmann::json
+make_sink_po_list(std::string_view po_kind, std::string_view block_id, std::string_view inst_id)
+{
+    nlohmann::json predicate_expr = {
+        {  "op",                                 "sink.marker"},
+        {"args", nlohmann::json::array({std::string(po_kind)})}
+    };
+    nlohmann::json po = {
+        {               "po_id",               make_sha256('b')                                },
+        {             "po_kind",                                           std::string(po_kind)},
+        {     "profile_version",                                               "safety.core.v1"},
+        {   "semantics_version",                                                       "sem.v1"},
+        {"proof_system_version",                                                     "proof.v1"},
+        {       "repo_identity",
+         nlohmann::json{{"path", "src/main.cpp"}, {"content_sha256", make_sha256('c')}}        },
+        {            "function",    nlohmann::json{{"usr", "usr::foo"}, {"mangled", "_Z3foov"}}},
+        {              "anchor",
+         nlohmann::json{{"block_id", std::string(block_id)}, {"inst_id", std::string(inst_id)}}},
+        {           "predicate",   nlohmann::json{{"expr", predicate_expr}, {"pretty", "sink"}}}
     };
 
     return nlohmann::json{
@@ -193,9 +241,9 @@ TEST(AnalyzerContractTest, LifetimePoProducesLifetimeUnknown)
     EXPECT_EQ(unknowns.at(0).at("unknown_code"), "LifetimeUnmodeled");
 }
 
-TEST(AnalyzerContractTest, DoubleFreePoProducesLifetimeUnknown)
+TEST(AnalyzerContractTest, DoubleFreePoProducesBug)
 {
-    auto temp_dir = ensure_temp_dir("sappp_analyzer_double_free_unknown");
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_double_free_bug");
     auto cert_dir = temp_dir / "certstore";
 
     Analyzer analyzer({
@@ -206,16 +254,108 @@ TEST(AnalyzerContractTest, DoubleFreePoProducesLifetimeUnknown)
                      .profile = "safety.core.v1"}
     });
 
-    auto nir = make_nir();
-    auto po_list = make_po_list("DoubleFree");
+    nlohmann::json insts = nlohmann::json::array({
+        {{"id", "I1"},       {"op", "alloc"},    {"args", nlohmann::json::array({"ptr", "new"})}},
+        {{"id", "I2"},        {"op", "free"}, {"args", nlohmann::json::array({"ptr", "delete"})}},
+        {{"id", "I3"}, {"op", "sink.marker"},   {"args", nlohmann::json::array({"double-free"})}},
+        {{"id", "I4"},        {"op", "free"}, {"args", nlohmann::json::array({"ptr", "delete"})}}
+    });
+    auto nir = make_nir_with_insts(insts);
+    auto po_list = make_sink_po_list("DoubleFree", "B1", "I3");
     auto specdb_snapshot = make_contract_snapshot(true);
 
     auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
-    ASSERT_EQ(unknowns.size(), 1U);
-    EXPECT_EQ(unknowns.at(0).at("unknown_code"), "LifetimeUnmodeled");
+    EXPECT_TRUE(unknowns.empty());
+
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    EXPECT_EQ(root_cert->at("result"), "BUG");
+}
+
+TEST(AnalyzerContractTest, InvalidFreePoProducesBug)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_invalid_free_bug");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    nlohmann::json insts = nlohmann::json::array({
+        {{"id", "I1"},        {"op", "free"}, {"args", nlohmann::json::array({"ptr", "delete"})}},
+        {{"id", "I2"}, {"op", "sink.marker"},  {"args", nlohmann::json::array({"invalid-free"})}}
+    });
+    auto nir = make_nir_with_insts(insts);
+    auto po_list = make_sink_po_list("InvalidFree", "B1", "I2");
+    auto specdb_snapshot = make_contract_snapshot(true);
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    EXPECT_TRUE(unknowns.empty());
+
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    EXPECT_EQ(root_cert->at("result"), "BUG");
+}
+
+TEST(AnalyzerContractTest, DoubleFreePoProducesSafe)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_double_free_safe");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    nlohmann::json insts = nlohmann::json::array({
+        {{"id", "I1"},       {"op", "alloc"},    {"args", nlohmann::json::array({"ptr", "new"})}},
+        {{"id", "I2"},        {"op", "free"}, {"args", nlohmann::json::array({"ptr", "delete"})}},
+        {{"id", "I3"}, {"op", "sink.marker"},   {"args", nlohmann::json::array({"double-free"})}}
+    });
+    auto nir = make_nir_with_insts(insts);
+    auto po_list = make_sink_po_list("DoubleFree", "B1", "I3");
+    auto specdb_snapshot = make_contract_snapshot(true);
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    EXPECT_TRUE(unknowns.empty());
+
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    EXPECT_EQ(root_cert->at("result"), "SAFE");
 }
 
 TEST(AnalyzerContractTest, UninitReadPoProducesInitUnknown)

--- a/tests/determinism/test_e2e_determinism.cpp
+++ b/tests/determinism/test_e2e_determinism.cpp
@@ -109,7 +109,7 @@ private:
     std::ofstream out(source_path);
     out << R"(#include <cstddef>
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, const char* target = nullptr);
 void sappp_check(const char* kind, bool predicate);
 
 struct Guard {
@@ -137,7 +137,7 @@ int use_after_lifetime() {
         int use_after_lifetime = 7;
         ptr = &use_after_lifetime;
     }
-    sappp_sink("use-after-lifetime");
+    sappp_sink("use-after-lifetime", "use_after_lifetime");
     return *ptr;
 }
 

--- a/tests/end_to_end/litmus_double_free.cpp
+++ b/tests/end_to_end/litmus_double_free.cpp
@@ -1,5 +1,5 @@
 // Litmus test: Double free
-// Expected: UNKNOWN (DoubleFree)
+// Expected: BUG (DoubleFree)
 
 void sappp_sink(const char* kind);
 

--- a/tests/end_to_end/litmus_invalid_free.cpp
+++ b/tests/end_to_end/litmus_invalid_free.cpp
@@ -1,0 +1,13 @@
+// Litmus test: Invalid free
+// Expected: BUG (InvalidFree)
+
+void sappp_sink(const char* kind);
+
+int main()
+{
+    int value = 3;
+    int* ptr = &value;
+    sappp_sink("invalid-free");
+    delete ptr;
+    return 0;
+}

--- a/tests/end_to_end/litmus_use_after_lifetime.cpp
+++ b/tests/end_to_end/litmus_use_after_lifetime.cpp
@@ -1,7 +1,7 @@
 // Litmus test: Use-after-lifetime
-// Expected: UNKNOWN (UseAfterLifetime)
+// Expected: BUG (UseAfterLifetime)
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, const char* target);
 
 int main()
 {
@@ -10,6 +10,6 @@ int main()
         int use_after_lifetime = 42;
         ptr = &use_after_lifetime;
     }
-    sappp_sink("use-after-lifetime");
+    sappp_sink("use-after-lifetime", "use_after_lifetime");
     return *ptr;
 }

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -329,8 +329,21 @@ TEST(LitmusE2E, DoubleFree)
         .name = "double_free",
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_double_free.cpp",
         .expected_po_kinds = {"DoubleFree"},
-        .expected_categories = {"UNKNOWN"},
-        .required_ops = {},
+        .expected_categories = {"BUG"},
+        .required_ops = {"alloc", "free"},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
+}
+
+TEST(LitmusE2E, InvalidFree)
+{
+    run_litmus_case(LitmusCase{
+        .name = "invalid_free",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_invalid_free.cpp",
+        .expected_po_kinds = {"InvalidFree"},
+        .expected_categories = {"BUG"},
+        .required_ops = {"free"},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
     });

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -316,7 +316,7 @@ TEST(LitmusE2E, UseAfterLifetime)
         .name = "use_after_lifetime",
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_use_after_lifetime.cpp",
         .expected_po_kinds = {"UseAfterLifetime"},
-        .expected_categories = {"UNKNOWN"},
+        .expected_categories = {"BUG"},
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,


### PR DESCRIPTION
## 概要
- frontend_clang に alloc/free イベントを追加
- Analyzer で DoubleFree/InvalidFree を BUG/SAFE 判定
- litmus/ユニットテストを更新し invalid_free を追加

## テスト
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14
- cmake --build build --parallel
- cmake -S . -B build-frontend -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14
- cmake --build build-frontend --parallel
- ctest --test-dir build-frontend --output-on-failure
- ctest --test-dir build-frontend -R determinism --output-on-failure

Closes #67