### PR TITLE
UninitReadの初期化解析を実装

### DIFF
--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -38,6 +38,40 @@ nlohmann::json make_nir()
     };
 }
 
+nlohmann::json make_nir_with_init_state(std::string_view var_id, std::string_view init_label)
+{
+    nlohmann::json function = {
+        {"function_uid","usr::foo"                        },
+        {"mangled_name",            "_Z3foov"},
+        {         "cfg",
+         {{"entry", "B1"},
+         {"blocks",
+         nlohmann::json::array({nlohmann::json{
+         {"id", "B1"},
+         {"insts",
+         nlohmann::json::array(
+         {nlohmann::json{
+         {"id", "I0"},
+         {"op", "assign"},
+         {"args",
+         nlohmann::json::array({std::string(var_id), std::string(init_label)})}},
+         nlohmann::json{{"id", "I1"},
+         {"op", "sink.marker"},
+         {"args",
+         nlohmann::json::array({std::string("uninit_read"),
+         std::string(var_id)})}}})}}})},
+         {"edges", nlohmann::json::array()}} }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                "nir.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {     "functions",            nlohmann::json::array({std::move(function)})}
+    };
+}
+
 nlohmann::json make_po_list(std::string_view po_kind)
 {
     nlohmann::json po = {
@@ -54,6 +88,36 @@ nlohmann::json make_po_list(std::string_view po_kind)
          nlohmann::json{
          {"expr", nlohmann::json{{"op", "custom.op"}, {"args", nlohmann::json::array({true})}}},
          {"pretty", "custom"}}                                                              }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                 "po.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {           "pos",                             nlohmann::json::array({po})}
+    };
+}
+
+nlohmann::json make_uninit_po_list(std::string_view var_id)
+{
+    nlohmann::json po = {
+        {               "po_id",            make_sha256('b')                                },
+        {             "po_kind",                                   std::string("UninitRead")},
+        {     "profile_version",                                            "safety.core.v1"},
+        {   "semantics_version",                                                    "sem.v1"},
+        {"proof_system_version",                                                  "proof.v1"},
+        {       "repo_identity",
+         nlohmann::json{{"path", "src/main.cpp"}, {"content_sha256", make_sha256('c')}}     },
+        {            "function", nlohmann::json{{"usr", "usr::foo"}, {"mangled", "_Z3foov"}}},
+        {              "anchor",       nlohmann::json{{"block_id", "B1"}, {"inst_id", "I1"}}},
+        {           "predicate",
+         nlohmann::json{{"expr",
+         nlohmann::json{{"op", "sink.marker"},
+         {"args",
+         nlohmann::json::array(
+         {std::string("UninitRead"), std::string(var_id)})}}},
+         {"pretty", "sink.marker"}}                                                         }
     };
 
     return nlohmann::json{
@@ -218,7 +282,7 @@ TEST(AnalyzerContractTest, DoubleFreePoProducesLifetimeUnknown)
     EXPECT_EQ(unknowns.at(0).at("unknown_code"), "LifetimeUnmodeled");
 }
 
-TEST(AnalyzerContractTest, UninitReadPoProducesInitUnknown)
+TEST(AnalyzerContractTest, UninitReadPoWithoutVarIdProducesUnknown)
 {
     auto temp_dir = ensure_temp_dir("sappp_analyzer_uninit_unknown");
     auto cert_dir = temp_dir / "certstore";
@@ -241,6 +305,68 @@ TEST(AnalyzerContractTest, UninitReadPoProducesInitUnknown)
     const auto& unknowns = output->unknown_ledger.at("unknowns");
     ASSERT_EQ(unknowns.size(), 1U);
     EXPECT_EQ(unknowns.at(0).at("unknown_code"), "DomainTooWeak.Memory");
+}
+
+TEST(AnalyzerContractTest, UninitReadPoDetectsBug)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_uninit_bug");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    auto nir = make_nir_with_init_state("value", "uninit");
+    auto po_list = make_uninit_po_list("value");
+    auto specdb_snapshot = make_contract_snapshot(true);
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    EXPECT_EQ(root_cert->at("result"), "BUG");
+}
+
+TEST(AnalyzerContractTest, UninitReadPoDetectsSafe)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_uninit_safe");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    auto nir = make_nir_with_init_state("value", "init");
+    auto po_list = make_uninit_po_list("value");
+    auto specdb_snapshot = make_contract_snapshot(true);
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    EXPECT_EQ(root_cert->at("result"), "SAFE");
 }
 
 }  // namespace sappp::analyzer::test

--- a/tests/determinism/test_e2e_determinism.cpp
+++ b/tests/determinism/test_e2e_determinism.cpp
@@ -109,7 +109,7 @@ private:
     std::ofstream out(source_path);
     out << R"(#include <cstddef>
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, ...);
 void sappp_check(const char* kind, bool predicate);
 
 struct Guard {
@@ -151,7 +151,7 @@ int double_free() {
 
 int uninit_read() {
     int value;
-    sappp_sink("uninit_read");
+    sappp_sink("uninit_read", value);
     return value;
 }
 

--- a/tests/end_to_end/litmus_uninit_read.cpp
+++ b/tests/end_to_end/litmus_uninit_read.cpp
@@ -1,11 +1,11 @@
 // Litmus test: Uninitialized read
-// Expected: UNKNOWN (UninitRead)
+// Expected: BUG (UninitRead)
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, ...);
 
 int main()
 {
     int value;
-    sappp_sink("uninit_read");
+    sappp_sink("uninit_read", value);
     return value;
 }

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -342,7 +342,7 @@ TEST(LitmusE2E, UninitRead)
         .name = "uninit_read",
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_uninit_read.cpp",
         .expected_po_kinds = {"UninitRead"},
-        .expected_categories = {"UNKNOWN"},
+        .expected_categories = {"BUG"},
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,


### PR DESCRIPTION
## Summary\n- UninitRead向けのinitドメイン解析を追加\n- frontendで変数IDと初期化ラベルを付与しsink.markerに引数を追加\n- litmus/ユニットテストをBUG/SAFE判定に更新\n\n## Testing\n- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON\n- cmake --build build --parallel\n- ctest --test-dir build --output-on-failure\n- ctest --test-dir build -R determinism --output-on-failure\n- ./scripts/docker-ci.sh --ci\n- ./scripts/agent-final-check.sh --until-ok