### PR TITLE
Implement points-to.simple in analyzer

### DIFF
--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <map>
 #include <optional>
 #include <ranges>
@@ -24,7 +25,12 @@ namespace sappp::analyzer {
 
 namespace {
 
-constexpr std::string_view kSafetyDomain = "interval+null+lifetime+init";
+constexpr std::string_view kBaseSafetyDomain = "interval+null+lifetime+init";
+constexpr std::string_view kPointsToDomain = "interval+null+lifetime+init+points-to.simple";
+constexpr std::string_view kPointsToNullTarget = "null";
+constexpr std::string_view kPointsToInBoundsTarget = "inbounds";
+constexpr std::string_view kPointsToOutOfBoundsTarget = "oob";
+constexpr std::size_t kMaxPointsToTargets = 4;
 constexpr std::string_view kDeterministicGeneratedAt = "1970-01-01T00:00:00Z";
 
 struct ContractInfo
@@ -639,6 +645,379 @@ build_lifetime_analysis_cache(const nlohmann::json& nir_json)  // NOLINT(readabi
     return cache;
 }
 
+struct PointsToSet
+{
+    bool is_unknown = false;
+    std::vector<std::string> targets;
+
+    // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+    PointsToSet()
+        : is_unknown(false)
+        , targets()
+    {}
+
+    PointsToSet(bool unknown, std::vector<std::string> targets_in)
+        : is_unknown(unknown)
+        , targets(std::move(targets_in))
+    {}
+
+    bool operator==(const PointsToSet&) const = default;
+};
+
+struct PointsToState
+{
+    std::map<std::string, PointsToSet> values;
+
+    PointsToState()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : values()
+    {}
+
+    bool operator==(const PointsToState&) const = default;
+};
+
+struct PointsToEffect
+{
+    std::string ptr;
+    std::vector<std::string> targets;
+
+    // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+    PointsToEffect()
+        : ptr()
+        , targets()
+    {}
+};
+
+[[nodiscard]] PointsToSet make_points_to_set(std::vector<std::string> targets)
+{
+    std::ranges::stable_sort(targets);
+    auto unique_end = std::ranges::unique(targets);
+    targets.erase(unique_end.begin(), targets.end());
+
+    if (targets.size() > kMaxPointsToTargets) {
+        return PointsToSet(true, {});
+    }
+
+    return PointsToSet(false, std::move(targets));
+}
+
+[[nodiscard]] PointsToSet merge_points_to_sets(const PointsToSet& a, const PointsToSet& b)
+{
+    if (a.is_unknown || b.is_unknown) {
+        return PointsToSet(true, {});
+    }
+
+    std::vector<std::string> merged = a.targets;
+    merged.insert(merged.end(), b.targets.begin(), b.targets.end());
+    return make_points_to_set(std::move(merged));
+}
+
+[[nodiscard]] PointsToState merge_points_to_states(const PointsToState& a, const PointsToState& b)
+{
+    PointsToState result;
+
+    for (const auto& [ptr, set] : a.values) {
+        PointsToSet other = PointsToSet(true, {});
+        auto it = b.values.find(ptr);
+        if (it != b.values.end()) {
+            other = it->second;
+        }
+        result.values.emplace(ptr, merge_points_to_sets(set, other));
+    }
+
+    for (const auto& [ptr, set] : b.values) {
+        if (result.values.contains(ptr)) {
+            continue;
+        }
+        PointsToSet other = PointsToSet(true, {});
+        auto it = a.values.find(ptr);
+        if (it != a.values.end()) {
+            other = it->second;
+        }
+        result.values.emplace(ptr, merge_points_to_sets(other, set));
+    }
+
+    return result;
+}
+
+[[nodiscard]] sappp::Result<std::vector<PointsToEffect>>
+extract_points_to_effects(const nlohmann::json& inst)
+{
+    if (!inst.contains("effects")) {
+        return std::vector<PointsToEffect>{};
+    }
+    if (!inst.at("effects").is_object()) {
+        return std::unexpected(
+            sappp::Error::make("InvalidFieldType", "Expected effects object in nir instruction"));
+    }
+
+    const auto& effects = inst.at("effects");
+    if (!effects.contains("points_to")) {
+        return std::vector<PointsToEffect>{};
+    }
+    if (!effects.at("points_to").is_array()) {
+        return std::unexpected(
+            sappp::Error::make("InvalidFieldType", "Expected effects.points_to array in nir"));
+    }
+
+    std::vector<PointsToEffect> output;
+    for (const auto& entry : effects.at("points_to")) {
+        if (!entry.is_object()) {
+            return std::unexpected(
+                sappp::Error::make("InvalidFieldType", "Expected points_to entry object in nir"));
+        }
+        if (!entry.contains("ptr") || !entry.contains("targets")) {
+            return std::unexpected(
+                sappp::Error::make("MissingField", "points_to entry missing ptr or targets"));
+        }
+        if (!entry.at("ptr").is_string() || !entry.at("targets").is_array()) {
+            return std::unexpected(
+                sappp::Error::make("InvalidFieldType", "points_to entry has invalid field types"));
+        }
+        PointsToEffect effect;
+        effect.ptr = entry.at("ptr").get<std::string>();
+        for (const auto& target : entry.at("targets")) {
+            if (!target.is_string()) {
+                return std::unexpected(
+                    sappp::Error::make("InvalidFieldType",
+                                       "points_to targets must be strings in nir"));
+            }
+            effect.targets.push_back(target.get<std::string>());
+        }
+        output.push_back(std::move(effect));
+    }
+
+    return output;
+}
+
+[[nodiscard]] sappp::VoidResult apply_points_to_effects(const nlohmann::json& inst,
+                                                        PointsToState& state)
+{
+    auto effects = extract_points_to_effects(inst);
+    if (!effects) {
+        return std::unexpected(effects.error());
+    }
+    for (const auto& effect : *effects) {
+        state.values[effect.ptr] = make_points_to_set(effect.targets);
+    }
+    return {};
+}
+
+struct FunctionPointsToAnalysis
+{
+    std::string function_uid;
+    std::string entry_block;
+    std::map<std::string, const nlohmann::json*> blocks;
+    std::vector<std::string> block_order;
+    std::map<std::string, std::vector<std::string>> predecessors;
+    std::map<std::string, PointsToState> in_states;
+    std::map<std::string, PointsToState> out_states;
+
+    // NOLINTBEGIN(readability-redundant-member-init) - required for -Weffc++.
+    FunctionPointsToAnalysis()
+        : function_uid()
+        , entry_block()
+        , blocks()
+        , block_order()
+        , predecessors()
+        , in_states()
+        , out_states()
+    {}
+    // NOLINTEND(readability-redundant-member-init)
+};
+
+struct PointsToAnalysisCache
+{
+    std::map<std::string, FunctionPointsToAnalysis> functions;
+
+    PointsToAnalysisCache()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : functions()
+    {}
+};
+
+[[nodiscard]] PointsToState
+merge_predecessor_points_to_states(const FunctionPointsToAnalysis& analysis,
+                                   std::string_view block_id)
+{
+    auto pred_it = analysis.predecessors.find(std::string(block_id));
+    if (pred_it == analysis.predecessors.end() || pred_it->second.empty()) {
+        return PointsToState{};
+    }
+
+    bool first = true;
+    PointsToState merged;
+    for (const auto& pred : pred_it->second) {
+        auto out_it = analysis.out_states.find(pred);
+        if (out_it == analysis.out_states.end()) {
+            continue;
+        }
+        if (first) {
+            merged = out_it->second;
+            first = false;
+            continue;
+        }
+        merged = merge_points_to_states(merged, out_it->second);
+    }
+
+    if (first) {
+        return PointsToState{};
+    }
+    return merged;
+}
+
+[[nodiscard]] sappp::Result<PointsToState>
+apply_points_to_block_transfer(const PointsToState& in_state, const nlohmann::json& block)
+{
+    PointsToState state = in_state;
+    if (!block.contains("insts") || !block.at("insts").is_array()) {
+        return state;
+    }
+    for (const auto& inst : block.at("insts")) {
+        if (auto applied = apply_points_to_effects(inst, state); !applied) {
+            return std::unexpected(applied.error());
+        }
+    }
+    return state;
+}
+
+[[nodiscard]] sappp::VoidResult compute_points_to_fixpoint(FunctionPointsToAnalysis& analysis)
+{
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto& block_id : analysis.block_order) {
+            PointsToState in_state = merge_predecessor_points_to_states(analysis, block_id);
+            auto in_it = analysis.in_states.find(block_id);
+            if (in_it == analysis.in_states.end() || in_it->second != in_state) {
+                analysis.in_states[block_id] = in_state;
+                changed = true;
+            }
+
+            auto block_it = analysis.blocks.find(block_id);
+            if (block_it == analysis.blocks.end()) {
+                continue;
+            }
+            auto out_state = apply_points_to_block_transfer(in_state, *block_it->second);
+            if (!out_state) {
+                return std::unexpected(out_state.error());
+            }
+            auto out_it = analysis.out_states.find(block_id);
+            if (out_it == analysis.out_states.end() || out_it->second != *out_state) {
+                analysis.out_states[block_id] = std::move(*out_state);
+                changed = true;
+            }
+        }
+    }
+    return {};
+}
+
+[[nodiscard]] sappp::Result<std::optional<PointsToState>>
+points_to_state_at_anchor(const FunctionPointsToAnalysis& analysis, const IrAnchor& anchor)
+{
+    auto block_it = analysis.blocks.find(anchor.block_id);
+    if (block_it == analysis.blocks.end()) {
+        return std::optional<PointsToState>();
+    }
+    auto in_it = analysis.in_states.find(anchor.block_id);
+    PointsToState state;
+    if (in_it != analysis.in_states.end()) {
+        state = in_it->second;
+    }
+    const nlohmann::json& block = *block_it->second;
+    if (!block.contains("insts") || !block.at("insts").is_array()) {
+        return std::optional<PointsToState>();
+    }
+    for (const auto& inst : block.at("insts")) {
+        if (inst.contains("id") && inst.at("id").is_string()
+            && inst.at("id").get<std::string>() == anchor.inst_id) {
+            return std::optional<PointsToState>(state);
+        }
+        if (auto applied = apply_points_to_effects(inst, state); !applied) {
+            return std::unexpected(applied.error());
+        }
+    }
+    return std::optional<PointsToState>();
+}
+
+[[nodiscard]] sappp::Result<PointsToAnalysisCache>
+build_points_to_analysis_cache(const nlohmann::json& nir_json)  // NOLINT(readability-function-size)
+{
+    PointsToAnalysisCache cache;
+    if (!nir_json.contains("functions") || !nir_json.at("functions").is_array()) {
+        return cache;
+    }
+
+    for (const auto& func : nir_json.at("functions")) {
+        if (!func.is_object()) {
+            continue;
+        }
+        if (!func.contains("function_uid") || !func.at("function_uid").is_string()) {
+            continue;
+        }
+        if (!func.contains("cfg") || !func.at("cfg").is_object()) {
+            continue;
+        }
+        const auto& cfg = func.at("cfg");
+        if (!cfg.contains("blocks") || !cfg.at("blocks").is_array()) {
+            continue;
+        }
+
+        FunctionPointsToAnalysis analysis;
+        analysis.function_uid = func.at("function_uid").get<std::string>();
+        if (cfg.contains("entry") && cfg.at("entry").is_string()) {
+            analysis.entry_block = cfg.at("entry").get<std::string>();
+        }
+
+        for (const auto& block : cfg.at("blocks")) {
+            if (!block.is_object() || !block.contains("id") || !block.at("id").is_string()) {
+                continue;
+            }
+            std::string block_id = block.at("id").get<std::string>();
+            analysis.block_order.push_back(block_id);
+            analysis.blocks.emplace(block_id, &block);
+            analysis.in_states.emplace(block_id, PointsToState{});
+            analysis.out_states.emplace(block_id, PointsToState{});
+        }
+
+        if (cfg.contains("edges") && cfg.at("edges").is_array()) {
+            for (const auto& edge : cfg.at("edges")) {
+                if (!edge.is_object()) {
+                    continue;
+                }
+                if (!edge.contains("from") || !edge.at("from").is_string()) {
+                    continue;
+                }
+                if (!edge.contains("to") || !edge.at("to").is_string()) {
+                    continue;
+                }
+                std::string from = edge.at("from").get<std::string>();
+                std::string to = edge.at("to").get<std::string>();
+                analysis.predecessors[to].push_back(std::move(from));
+            }
+        }
+
+        for (auto& [block_id, preds] : analysis.predecessors) {
+            (void)block_id;
+            std::ranges::stable_sort(preds);
+            auto unique_end = std::ranges::unique(preds);
+            preds.erase(unique_end.begin(), preds.end());
+        }
+
+        if (!analysis.block_order.empty()) {
+            if (analysis.entry_block.empty()) {
+                analysis.entry_block = analysis.block_order.front();
+            }
+            if (auto fixpoint = compute_points_to_fixpoint(analysis); !fixpoint) {
+                return std::unexpected(fixpoint.error());
+            }
+            cache.functions.emplace(analysis.function_uid, std::move(analysis));
+        }
+    }
+
+    return cache;
+}
+
 [[nodiscard]] nlohmann::json
 make_ir_ref_obj(const std::string& tu_id, const std::string& function_uid, const IrAnchor& anchor)
 {
@@ -670,13 +1049,18 @@ make_ir_ref_obj(const std::string& tu_id, const std::string& function_uid, const
 [[nodiscard]] nlohmann::json make_safety_proof(const std::string& function_uid,
                                                const IrAnchor& anchor,
                                                const nlohmann::json& predicate_expr,
-                                               bool predicate_holds)
+                                               bool predicate_holds,
+                                               const std::optional<nlohmann::json>& points_to,
+                                               std::string_view domain)
 {
     nlohmann::json state = nlohmann::json::object();
     if (predicate_holds) {
         state["predicates"] = nlohmann::json::array({predicate_expr});
     } else {
         state["predicates"] = nlohmann::json::array();
+    }
+    if (points_to) {
+        state["points_to"] = *points_to;
     }
 
     nlohmann::json point = nlohmann::json{
@@ -690,7 +1074,7 @@ make_ir_ref_obj(const std::string& tu_id, const std::string& function_uid, const
     return nlohmann::json{
         {"schema_version",                      "cert.v1"},
         {          "kind",                  "SafetyProof"},
-        {        "domain",     std::string(kSafetyDomain)},
+        {        "domain",            std::string(domain)},
         {        "points", nlohmann::json::array({point})},
         {        "pretty",                   "stub proof"}
     };
@@ -1072,6 +1456,7 @@ struct PoProcessingContext
     const ContractIndex* contract_index = nullptr;
     std::unordered_map<std::string, std::string>* contract_ref_cache = nullptr;
     const LifetimeAnalysisCache* lifetime_cache = nullptr;
+    const PointsToAnalysisCache* points_to_cache = nullptr;
     std::string_view tu_id;
     const sappp::VersionTriple* versions = nullptr;
 };
@@ -1098,6 +1483,8 @@ struct EvidenceInput
     const IrAnchor* anchor = nullptr;
     bool is_bug = false;
     bool is_safe = false;
+    const std::optional<nlohmann::json>* points_to = nullptr;
+    std::string_view safety_domain = kBaseSafetyDomain;
 };
 
 [[nodiscard]] sappp::Result<EvidenceResult> build_evidence(const EvidenceInput& input)
@@ -1115,7 +1502,11 @@ struct EvidenceInput
     EvidenceResult output{.evidence = make_safety_proof(std::string(input.function_uid),
                                                         *input.anchor,
                                                         *predicate_expr,
-                                                        input.is_safe),
+                                                        input.is_safe,
+                                                        input.points_to != nullptr
+                                                            ? *input.points_to
+                                                            : std::optional<nlohmann::json>(),
+                                                        input.safety_domain),
                           .result_kind = "SAFE"};
     return output;
 }
@@ -1164,7 +1555,9 @@ struct PoBaseData
 [[nodiscard]] sappp::VoidResult store_po_proof(const nlohmann::json& po,
                                                const PoBaseData& base,
                                                const PoProcessingContext& context,
-                                               const std::vector<std::string>& contract_hashes)
+                                               const std::vector<std::string>& contract_hashes,
+                                               const std::optional<nlohmann::json>& points_to,
+                                               std::string_view safety_domain)
 {
     auto po_hash = put_cert(*context.cert_store, base.po_def);
     if (!po_hash) {
@@ -1182,7 +1575,9 @@ struct PoBaseData
                                  .function_uid = base.function_uid,
                                  .anchor = &base.anchor,
                                  .is_bug = base.is_bug,
-                                 .is_safe = base.is_safe};
+                                 .is_safe = base.is_safe,
+                                 .points_to = &points_to,
+                                 .safety_domain = safety_domain};
     auto evidence_result = build_evidence(evidence_input);
     if (!evidence_result) {
         return std::unexpected(evidence_result.error());
@@ -1260,6 +1655,8 @@ struct PoDecision
     bool is_safe = false;
     bool is_unknown = false;
     UnknownDetails unknown_details{};
+    std::optional<nlohmann::json> points_to = std::nullopt;
+    std::string safety_domain = std::string(kBaseSafetyDomain);
 };
 
 [[nodiscard]] sappp::Result<std::optional<bool>>
@@ -1300,6 +1697,135 @@ extract_lifetime_target(const nlohmann::json& predicate_expr)
         return args.at(0).get<std::string>();
     }
     return std::nullopt;
+}
+
+[[nodiscard]] std::optional<std::string>
+extract_points_to_pointer(const nlohmann::json& predicate_expr)
+{
+    if (!predicate_expr.contains("args") || !predicate_expr.at("args").is_array()) {
+        return std::nullopt;
+    }
+    const auto& args = predicate_expr.at("args");
+    if (args.size() < 2) {
+        return std::nullopt;
+    }
+    if (!args.at(1).is_string()) {
+        return std::nullopt;
+    }
+    return args.at(1).get<std::string>();
+}
+
+[[nodiscard]] bool points_to_contains(const PointsToSet& set, std::string_view target)
+{
+    return std::ranges::find(set.targets, target) != set.targets.end();
+}
+
+[[nodiscard]] nlohmann::json build_points_to_entries(std::string_view ptr, const PointsToSet& set)
+{
+    return nlohmann::json::array({
+        nlohmann::json{{"ptr", std::string(ptr)}, {"targets", set.targets}}
+    });
+}
+
+[[nodiscard]] sappp::Result<std::optional<PoDecision>>
+decide_points_to(const nlohmann::json& po,
+                 const nlohmann::json& predicate_expr,
+                 std::string_view po_kind,
+                 const PoProcessingContext& context)
+{
+    if (context.points_to_cache == nullptr || context.function_uid_map == nullptr) {
+        return std::optional<PoDecision>();
+    }
+
+    auto pointer = extract_points_to_pointer(predicate_expr);
+    if (!pointer) {
+        return std::optional<PoDecision>();
+    }
+
+    auto function_uid = resolve_function_uid(*context.function_uid_map, po);
+    if (!function_uid) {
+        return std::unexpected(function_uid.error());
+    }
+    auto anchor = extract_anchor(po);
+    if (!anchor) {
+        return std::unexpected(anchor.error());
+    }
+
+    auto analysis_it = context.points_to_cache->functions.find(*function_uid);
+    if (analysis_it == context.points_to_cache->functions.end()) {
+        return std::optional<PoDecision>();
+    }
+
+    auto state = points_to_state_at_anchor(analysis_it->second, *anchor);
+    if (!state) {
+        return std::unexpected(state.error());
+    }
+    if (!state->has_value()) {
+        return std::optional<PoDecision>();
+    }
+
+    auto set_it = state->value().values.find(*pointer);
+    if (set_it == state->value().values.end()) {
+        return std::optional<PoDecision>();
+    }
+
+    const PointsToSet& points_to_set = set_it->second;
+    if (points_to_set.is_unknown || points_to_set.targets.empty()) {
+        PoDecision decision;
+        decision.is_unknown = true;
+        decision.unknown_details = build_unknown_details(po_kind);
+        return std::optional<PoDecision>(decision);
+    }
+
+    if (po_kind == "UB.NullDeref") {
+        const bool has_null = points_to_contains(points_to_set, kPointsToNullTarget);
+        if (has_null) {
+            if (points_to_set.targets.size() == 1U) {
+                PoDecision decision;
+                decision.is_bug = true;
+                return std::optional<PoDecision>(decision);
+            }
+            PoDecision decision;
+            decision.is_unknown = true;
+            decision.unknown_details = build_unknown_details(po_kind);
+            return std::optional<PoDecision>(decision);
+        }
+
+        PoDecision decision;
+        decision.is_safe = true;
+        decision.points_to = build_points_to_entries(*pointer, points_to_set);
+        decision.safety_domain = std::string(kPointsToDomain);
+        return std::optional<PoDecision>(decision);
+    }
+
+    if (po_kind == "UB.OutOfBounds") {
+        const bool has_oob = points_to_contains(points_to_set, kPointsToOutOfBoundsTarget);
+        const bool has_inbounds = points_to_contains(points_to_set, kPointsToInBoundsTarget);
+        if (has_oob) {
+            if (points_to_set.targets.size() == 1U) {
+                PoDecision decision;
+                decision.is_bug = true;
+                return std::optional<PoDecision>(decision);
+            }
+            PoDecision decision;
+            decision.is_unknown = true;
+            decision.unknown_details = build_unknown_details(po_kind);
+            return std::optional<PoDecision>(decision);
+        }
+        if (has_inbounds && points_to_set.targets.size() == 1U) {
+            PoDecision decision;
+            decision.is_safe = true;
+            decision.points_to = build_points_to_entries(*pointer, points_to_set);
+            decision.safety_domain = std::string(kPointsToDomain);
+            return std::optional<PoDecision>(decision);
+        }
+        PoDecision decision;
+        decision.is_unknown = true;
+        decision.unknown_details = build_unknown_details(po_kind);
+        return std::optional<PoDecision>(decision);
+    }
+
+    return std::optional<PoDecision>();
 }
 
 [[nodiscard]] sappp::Result<PoDecision>
@@ -1419,6 +1945,16 @@ decide_use_after_lifetime(  // NOLINTNEXTLINE(bugprone-easily-swappable-paramete
         return *decision;
     }
 
+    if (*po_kind == "UB.NullDeref" || *po_kind == "UB.OutOfBounds") {
+        auto points_to_decision = decide_points_to(po, *predicate_expr, *po_kind, context);
+        if (!points_to_decision) {
+            return std::unexpected(points_to_decision.error());
+        }
+        if (points_to_decision->has_value()) {
+            return points_to_decision->value();
+        }
+    }
+
     if (op == "sink.marker") {
         if (*po_kind == "UB.OutOfBounds" || *po_kind == "UB.NullDeref") {
             PoDecision decision;
@@ -1474,7 +2010,13 @@ resolve_contracts(const nlohmann::json& po, const PoProcessingContext& context)
         return std::unexpected(base.error());
     }
 
-    if (auto stored = store_po_proof(po, *base, context, contract_hashes); !stored) {
+    if (auto stored = store_po_proof(po,
+                                     *base,
+                                     context,
+                                     contract_hashes,
+                                     decision->points_to,
+                                     decision->safety_domain);
+        !stored) {
         return std::unexpected(stored.error());
     }
 
@@ -1565,6 +2107,10 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
         return std::unexpected(contract_index.error());
     }
     const auto lifetime_cache = build_lifetime_analysis_cache(nir_json);
+    auto points_to_cache = build_points_to_analysis_cache(nir_json);
+    if (!points_to_cache) {
+        return std::unexpected(points_to_cache.error());
+    }
     std::unordered_map<std::string, std::string> contract_ref_cache;
 
     std::vector<nlohmann::json> unknowns;
@@ -1575,6 +2121,7 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
                                 .contract_index = &(*contract_index),
                                 .contract_ref_cache = &contract_ref_cache,
                                 .lifetime_cache = &lifetime_cache,
+                                .points_to_cache = &(*points_to_cache),
                                 .tu_id = *tu_id,
                                 .versions = &m_config.versions};
 

--- a/tests/analyzer/CMakeLists.txt
+++ b/tests/analyzer/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(analyzer_tests
     test_analyzer_contracts.cpp
+    test_analyzer_points_to.cpp
 )
 
 sappp_target_strict_warnings(analyzer_tests)

--- a/tests/analyzer/test_analyzer_points_to.cpp
+++ b/tests/analyzer/test_analyzer_points_to.cpp
@@ -1,0 +1,210 @@
+#include "analyzer.hpp"
+#include "sappp/certstore.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace sappp::analyzer::test {
+
+namespace {
+
+std::string make_sha256(char fill)
+{
+    return std::string("sha256:") + std::string(64, fill);
+}
+
+std::filesystem::path ensure_temp_dir(const std::string& name)
+{
+    auto temp_dir = std::filesystem::temp_directory_path() / name;
+    std::error_code ec;
+    std::filesystem::remove_all(temp_dir, ec);
+    std::filesystem::create_directories(temp_dir, ec);
+    return temp_dir;
+}
+
+nlohmann::json make_nir_with_points_to()
+{
+    nlohmann::json safe_inst = {
+        {     "id",                                                      "I0"                   },
+        {     "op",                                                                     "assign"},
+        {"effects",
+         nlohmann::json{{"points_to",
+         nlohmann::json::array(
+         {nlohmann::json{{"ptr", "p"},
+         {"targets", nlohmann::json::array({"alloc1"})}}})}}                                    }
+    };
+    nlohmann::json safe_anchor_inst = {
+        {"id",         "I1"},
+        {"op", "custom.ptr"}
+    };
+
+    nlohmann::json safe_block = {
+        {   "id",                                                 "B0"},
+        {"insts", nlohmann::json::array({safe_inst, safe_anchor_inst})}
+    };
+
+    nlohmann::json safe_func = {
+        {"function_uid","usr::safe"                        },
+        {"mangled_name",                         "_Z4safev"},
+        {         "cfg",
+         nlohmann::json{{"entry", "B0"},
+         {"blocks", nlohmann::json::array({safe_block})},
+         {"edges", nlohmann::json::array()}}               }
+    };
+
+    nlohmann::json unknown_block = {
+        {   "id",                                                                       "B0"},
+        {"insts", nlohmann::json::array({nlohmann::json{{"id", "I0"}, {"op", "custom.op"}}})}
+    };
+
+    nlohmann::json unknown_func = {
+        {"function_uid","usr::unknown"                        },
+        {"mangled_name",                      "_Z7unknownv"},
+        {         "cfg",
+         nlohmann::json{{"entry", "B0"},
+         {"blocks", nlohmann::json::array({unknown_block})},
+         {"edges", nlohmann::json::array()}}               }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                "nir.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {     "functions",        nlohmann::json::array({safe_func, unknown_func})}
+    };
+}
+
+nlohmann::json make_po_list_with_points_to()
+{
+    nlohmann::json safe_po = {
+        {               "po_id",              make_sha256('b')                                },
+        {             "po_kind",                                                "UB.NullDeref"},
+        {     "profile_version",                                              "safety.core.v1"},
+        {   "semantics_version",                                                      "sem.v1"},
+        {"proof_system_version",                                                    "proof.v1"},
+        {       "repo_identity",
+         nlohmann::json{{"path", "src/safe.cpp"}, {"content_sha256", make_sha256('e')}}       },
+        {            "function", nlohmann::json{{"usr", "usr::safe"}, {"mangled", "_Z4safev"}}},
+        {              "anchor",         nlohmann::json{{"block_id", "B0"}, {"inst_id", "I1"}}},
+        {           "predicate",
+         nlohmann::json{{"expr",
+         nlohmann::json{{"op", "custom.ptr"},
+         {"args", nlohmann::json::array({"UB.NullDeref", "p"})}}},
+         {"pretty", "custom.ptr"}}                                                            }
+    };
+
+    nlohmann::json unknown_po = {
+        {               "po_id",                    make_sha256('c')                                },
+        {             "po_kind",                                                        "UB.DivZero"},
+        {     "profile_version",                                                    "safety.core.v1"},
+        {   "semantics_version",                                                            "sem.v1"},
+        {"proof_system_version",                                                          "proof.v1"},
+        {       "repo_identity",
+         nlohmann::json{{"path", "src/unknown.cpp"}, {"content_sha256", make_sha256('f')}}          },
+        {            "function", nlohmann::json{{"usr", "usr::unknown"}, {"mangled", "_Z7unknownv"}}},
+        {              "anchor",               nlohmann::json{{"block_id", "B0"}, {"inst_id", "I0"}}},
+        {           "predicate",
+         nlohmann::json{
+         {"expr",
+         nlohmann::json{{"op", "custom.op"}, {"args", nlohmann::json::array({"UB.DivZero"})}}},
+         {"pretty", "custom.op"}}                                                                   }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                 "po.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {           "pos",            nlohmann::json::array({safe_po, unknown_po})}
+    };
+}
+
+nlohmann::json make_contract_snapshot_for_safe()
+{
+    nlohmann::json contracts = nlohmann::json::array();
+    contracts.push_back(nlohmann::json{
+        {"schema_version",                        "contract_ir.v1"                          },
+        {   "contract_id",                                                  make_sha256('d')},
+        {        "target",                              nlohmann::json{{"usr", "usr::safe"}}},
+        {          "tier",                                                           "Tier1"},
+        { "version_scope",
+         nlohmann::json{{"abi", "x86_64"},
+         {"library_version", "1.0.0"},
+         {"conditions", nlohmann::json::array()},
+         {"priority", 0}}                                                                   },
+        {      "contract",
+         nlohmann::json{
+         {"pre",
+         nlohmann::json{{"expr", nlohmann::json{{"op", "true"}}}, {"pretty", "true"}}}}     }
+    });
+
+    return nlohmann::json{
+        {"schema_version",                                    "specdb_snapshot.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {     "contracts",                                               contracts}
+    };
+}
+
+}  // namespace
+
+TEST(AnalyzerPointsToTest, PointsToSimpleResolvesNullDeref)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_points_to");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    auto nir = make_nir_with_points_to();
+    auto po_list = make_po_list_with_points_to();
+    auto specdb_snapshot = make_contract_snapshot_for_safe();
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    ASSERT_EQ(unknowns.size(), 1U);
+    EXPECT_EQ(unknowns.at(0).at("unknown_code"), "MissingContract.Pre");
+    EXPECT_EQ(unknowns.at(0).at("po_id").get<std::string>(), make_sha256('c'));
+
+    sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
+    std::ifstream index_file(cert_dir / "index" / (make_sha256('b') + ".json"));
+    ASSERT_TRUE(index_file.is_open());
+    nlohmann::json index_json = nlohmann::json::parse(index_file);
+    std::string root_hash = index_json.at("root").get<std::string>();
+
+    auto root_cert = cert_store.get(root_hash);
+    ASSERT_TRUE(root_cert);
+    EXPECT_EQ(root_cert->at("result"), "SAFE");
+
+    std::string evidence_hash = root_cert->at("evidence").at("ref").get<std::string>();
+    auto evidence_cert = cert_store.get(evidence_hash);
+    ASSERT_TRUE(evidence_cert);
+    EXPECT_EQ(evidence_cert->at("kind"), "SafetyProof");
+    EXPECT_EQ(evidence_cert->at("domain"), "interval+null+lifetime+init+points-to.simple");
+
+    const auto& points = evidence_cert->at("points");
+    ASSERT_EQ(points.size(), 1U);
+    const auto& state = points.at(0).at("state");
+    ASSERT_TRUE(state.contains("points_to"));
+    const auto& points_to = state.at("points_to");
+    ASSERT_TRUE(points_to.is_array());
+    ASSERT_EQ(points_to.size(), 1U);
+    EXPECT_EQ(points_to.at(0).at("ptr"), "p");
+    const auto& targets = points_to.at(0).at("targets");
+    ASSERT_EQ(targets.size(), 1U);
+    EXPECT_EQ(targets.at(0), "alloc1");
+}
+
+}  // namespace sappp::analyzer::test


### PR DESCRIPTION
## Summary
- add points-to.simple dataflow analysis and propagate points_to into SafetyProof
- resolve NullDeref/OutOfBounds when points-to data is available
- add analyzer unit test for points-to resolution

## Tests
- cmake -S . -B build-issue73 -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14
- cmake --build build-issue73 --parallel
- ctest --test-dir build-issue73 --output-on-failure
- ctest --test-dir build-issue73 -R determinism --output-on-failure
