### PR TITLE
UninitReadの初期化解析を追加

### DIFF
--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -649,7 +649,8 @@ extract_first_string_arg(const nlohmann::json& inst)  // NOLINTNEXTLINE(readabil
 
 [[nodiscard]] bool is_unknown_label(std::string_view label)
 {
-    return label.empty() || label == "ref" || label == "expr";
+    return label.empty() || label == "ref" || label == "expr" || label == "unknown"
+           || label.starts_with("temporary");
 }
 
 [[nodiscard]] std::optional<bool> extract_init_flag(const nlohmann::json& arg)
@@ -667,6 +668,7 @@ extract_first_string_arg(const nlohmann::json& inst)  // NOLINTNEXTLINE(readabil
         }
     }
     return std::nullopt;
+}
 }
 
 void apply_lifetime_effect(const nlohmann::json& inst, LifetimeState& state)

--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -669,7 +669,6 @@ extract_first_string_arg(const nlohmann::json& inst)  // NOLINTNEXTLINE(readabil
     }
     return std::nullopt;
 }
-}
 
 void apply_lifetime_effect(const nlohmann::json& inst, LifetimeState& state)
 {

--- a/libs/frontend_clang/frontend.cpp
+++ b/libs/frontend_clang/frontend.cpp
@@ -727,7 +727,12 @@ std::optional<ClassifiedStmt> classify_assign_stmt(const clang::Stmt* stmt)
     std::vector<nlohmann::json> args;
     for (const auto* decl : decl_stmt->decls()) {
         if (const auto* var_decl = clang::dyn_cast<clang::VarDecl>(decl)) {
+            bool is_init = var_decl->hasInit();
+            if (var_decl->hasGlobalStorage()) {
+                is_init = true;
+            }
             args.push_back(build_ref_from_decl(var_decl));
+            args.push_back(is_init);
         }
     }
     if (args.empty()) {

--- a/tests/determinism/test_e2e_determinism.cpp
+++ b/tests/determinism/test_e2e_determinism.cpp
@@ -109,7 +109,7 @@ private:
     std::ofstream out(source_path);
     out << R"(#include <cstddef>
 
-void sappp_sink(const char* kind, const char* target = nullptr);
+void sappp_sink(const char* kind, ...);
 void sappp_check(const char* kind, bool predicate);
 
 struct Guard {
@@ -151,7 +151,7 @@ int double_free() {
 
 int uninit_read() {
     int value;
-    sappp_sink("uninit_read");
+    sappp_sink("uninit_read", value);
     return value;
 }
 

--- a/tests/end_to_end/litmus_uninit_read.cpp
+++ b/tests/end_to_end/litmus_uninit_read.cpp
@@ -1,11 +1,11 @@
 // Litmus test: Uninitialized read
-// Expected: UNKNOWN (UninitRead)
+// Expected: BUG (UninitRead)
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, int target);
 
 int main()
 {
     int value;
-    sappp_sink("uninit_read");
+    sappp_sink("uninit_read", value);
     return value;
 }

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -367,7 +367,7 @@ TEST(LitmusE2E, UninitRead)
         .name = "uninit_read",
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_uninit_read.cpp",
         .expected_po_kinds = {"UninitRead"},
-        .expected_categories = {"UNKNOWN"},
+        .expected_categories = {"BUG"},
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -306,6 +306,7 @@ TEST(LitmusE2E, Div0)
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
+        .expected_unknown_codes = {},
     });
 }
 
@@ -319,6 +320,7 @@ TEST(LitmusE2E, NullDeref)
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
+        .expected_unknown_codes = {},
     });
 }
 
@@ -332,6 +334,7 @@ TEST(LitmusE2E, OutOfBounds)
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
+        .expected_unknown_codes = {},
     });
 }
 
@@ -345,6 +348,7 @@ TEST(LitmusE2E, UseAfterLifetime)
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
+        .expected_unknown_codes = {},
     });
 }
 
@@ -358,6 +362,7 @@ TEST(LitmusE2E, DoubleFree)
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
+        .expected_unknown_codes = {},
     });
 }
 
@@ -371,6 +376,7 @@ TEST(LitmusE2E, UninitRead)
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
+        .expected_unknown_codes = {},
     });
 }
 
@@ -384,6 +390,7 @@ TEST(LitmusE2E, ExceptionRaii)
         .required_ops = {"invoke", "throw", "landingpad", "dtor"},
         .required_edge_kinds = {"exception"},
         .require_vcall_candidates = false,
+        .expected_unknown_codes = {},
     });
 }
 


### PR DESCRIPTION
## Summary\n- init ドメイン解析で UninitRead を BUG/SAFE 判定\n- assign/store/load に変数ラベルと初期化フラグを付与\n- litmus/analyzer テストを更新\n\n## Testing\n- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON\n- cmake --build build --parallel\n- ctest --test-dir build --output-on-failure\n- ctest --test-dir build -R determinism --output-on-failure\n- ./scripts/pre-commit-check.sh --ci (clang++-19 not found で失敗)\n\nCloses #66