### PR TITLE
Issue #67: new/delete IR events + DoubleFree/InvalidFree

### DIFF
--- a/libs/validator/validator.cpp
+++ b/libs/validator/validator.cpp
@@ -1336,11 +1336,11 @@ ValidationError rule_violation_error(const std::string& message)
 
 [[nodiscard]] bool is_supported_bug_trace_op(std::string_view op)
 {
-    constexpr std::array<std::string_view, 19> kSupportedOps{
+    constexpr std::array<std::string_view, 21> kSupportedOps{
         {
-         "assign",         "branch",       "call",  "ctor",     "dtor",  "invoke", "landingpad",
-         "lifetime.begin", "lifetime.end", "load",  "move",     "ret",   "resume", "sink.marker",
-         "stmt",           "store",        "throw", "ub.check", "vcall",
+         "alloc",  "assign",      "branch",         "call",         "ctor",  "dtor",     "free",
+         "invoke", "landingpad",  "lifetime.begin", "lifetime.end", "load",  "move",     "ret",
+         "resume", "sink.marker", "stmt",           "store",        "throw", "ub.check", "vcall",
          }
     };
     return std::ranges::find(kSupportedOps, op) != kSupportedOps.end();

--- a/tests/determinism/test_e2e_determinism.cpp
+++ b/tests/determinism/test_e2e_determinism.cpp
@@ -109,7 +109,7 @@ private:
     std::ofstream out(source_path);
     out << R"(#include <cstddef>
 
-void sappp_sink(const char* kind, const char* target = nullptr);
+void sappp_sink(const char* kind, const void* target = nullptr);
 void sappp_check(const char* kind, bool predicate);
 
 struct Guard {
@@ -144,7 +144,7 @@ int use_after_lifetime() {
 int double_free() {
     int* ptr = new int(1);
     delete ptr;
-    sappp_sink("double_free");
+    sappp_sink("double_free", ptr);
     delete ptr;
     return 0;
 }

--- a/tests/end_to_end/litmus_double_free.cpp
+++ b/tests/end_to_end/litmus_double_free.cpp
@@ -1,13 +1,13 @@
 // Litmus test: Double free
-// Expected: UNKNOWN (DoubleFree)
+// Expected: BUG (DoubleFree)
 
-void sappp_sink(const char* kind);
+void sappp_sink(const char* kind, const void* target);
 
 int main()
 {
     int* ptr = new int(7);
     delete ptr;
-    sappp_sink("double-free");
+    sappp_sink("double-free", ptr);
     delete ptr;
     return 0;
 }

--- a/tests/end_to_end/litmus_invalid_free.cpp
+++ b/tests/end_to_end/litmus_invalid_free.cpp
@@ -1,0 +1,13 @@
+// Litmus test: Invalid free
+// Expected: BUG (InvalidFree)
+
+void sappp_sink(const char* kind, const void* target);
+
+int main()
+{
+    int value = 7;
+    int* ptr = &value;
+    sappp_sink("invalid-free", ptr);
+    delete ptr;
+    return 0;
+}

--- a/tests/end_to_end/litmus_use_after_lifetime.cpp
+++ b/tests/end_to_end/litmus_use_after_lifetime.cpp
@@ -1,7 +1,7 @@
 // Litmus test: Use-after-lifetime
 // Expected: BUG (UseAfterLifetime)
 
-void sappp_sink(const char* kind, const char* target);
+void sappp_sink(const char* kind, const void* target);
 
 int main()
 {

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -329,8 +329,21 @@ TEST(LitmusE2E, DoubleFree)
         .name = "double_free",
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_double_free.cpp",
         .expected_po_kinds = {"DoubleFree"},
-        .expected_categories = {"UNKNOWN"},
-        .required_ops = {},
+        .expected_categories = {"BUG"},
+        .required_ops = {"alloc", "free"},
+        .required_edge_kinds = {},
+        .require_vcall_candidates = false,
+    });
+}
+
+TEST(LitmusE2E, InvalidFree)
+{
+    run_litmus_case(LitmusCase{
+        .name = "invalid_free",
+        .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_invalid_free.cpp",
+        .expected_po_kinds = {"InvalidFree"},
+        .expected_categories = {"BUG"},
+        .required_ops = {"free"},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,
     });


### PR DESCRIPTION
## Summary
- add alloc/free IR events for new/delete and heap lifetime tracking
- classify DoubleFree/InvalidFree in analyzer and allow validator ops
- update litmus, determinism, frontend/analyzer tests

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON
- cmake --build build --parallel
- cmake -S . -B build-clang -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14
- cmake --build build-clang --parallel
- ctest --test-dir build --output-on-failure
- ctest --test-dir build -R determinism --output-on-failure
- ctest --test-dir build-clang --output-on-failure