### PR TITLE
Issue #76: Analyzerの予算対応とBudgetExceeded

### DIFF
--- a/libs/analyzer/analyzer.hpp
+++ b/libs/analyzer/analyzer.hpp
@@ -8,6 +8,8 @@
 #include "sappp/common.hpp"
 #include "sappp/version.hpp"
 
+#include <cstdint>
+#include <optional>
 #include <string>
 
 #include <nlohmann/json.hpp>
@@ -19,6 +21,14 @@ struct AnalyzerConfig
     std::string schema_dir;
     std::string certstore_dir;
     sappp::VersionTriple versions;
+    struct AnalysisBudget
+    {
+        std::optional<std::uint64_t> max_iterations;
+        std::optional<std::uint64_t> max_states;
+        std::optional<std::uint64_t> max_summary_nodes;
+        std::optional<std::uint64_t> max_time_ms;
+    } budget{};
+    std::optional<std::string> memory_domain;
 };
 
 struct AnalyzeOutput

--- a/tests/analyzer/CMakeLists.txt
+++ b/tests/analyzer/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(analyzer_tests
+    test_analyzer_budget.cpp
     test_analyzer_contracts.cpp
     test_analyzer_unknown_codes.cpp
     test_analyzer_points_to.cpp

--- a/tests/analyzer/test_analyzer_budget.cpp
+++ b/tests/analyzer/test_analyzer_budget.cpp
@@ -1,0 +1,146 @@
+#include "analyzer.hpp"
+
+#include <filesystem>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace sappp::analyzer::test {
+
+namespace {
+
+std::string make_sha256(char fill)
+{
+    return std::string("sha256:") + std::string(64, fill);
+}
+
+std::filesystem::path ensure_temp_dir(const std::string& name)
+{
+    auto temp_dir = std::filesystem::temp_directory_path() / name;
+    std::error_code ec;
+    std::filesystem::remove_all(temp_dir, ec);
+    std::filesystem::create_directories(temp_dir, ec);
+    return temp_dir;
+}
+
+nlohmann::json make_nir_with_two_blocks()
+{
+    nlohmann::json block0 = {
+        {   "id",                                                                    "B0"},
+        {"insts", nlohmann::json::array({nlohmann::json{{"id", "I0"}, {"op", "assign"}}})}
+    };
+
+    nlohmann::json block1 = {
+        {   "id",                                                                         "B1"},
+        {"insts", nlohmann::json::array({nlohmann::json{{"id", "I1"}, {"op", "sink.marker"}}})}
+    };
+
+    nlohmann::json func = {
+        {"function_uid",                   "usr::foo"                        },
+        {"mangled_name",                                            "_Z3foov"},
+        {         "cfg",
+         {{"entry", "B0"},
+         {"blocks", nlohmann::json::array({block0, block1})},
+         {"edges", nlohmann::json::array({{{"from", "B0"}, {"to", "B1"}}})}} }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                "nir.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {     "functions",                           nlohmann::json::array({func})}
+    };
+}
+
+nlohmann::json make_po_list()
+{
+    nlohmann::json po = {
+        {               "po_id",            make_sha256('b')                                },
+        {             "po_kind",                                                "UB.DivZero"},
+        {     "profile_version",                                            "safety.core.v1"},
+        {   "semantics_version",                                                    "sem.v1"},
+        {"proof_system_version",                                                  "proof.v1"},
+        {       "repo_identity",
+         nlohmann::json{{"path", "src/main.cpp"}, {"content_sha256", make_sha256('c')}}     },
+        {            "function", nlohmann::json{{"usr", "usr::foo"}, {"mangled", "_Z3foov"}}},
+        {              "anchor",       nlohmann::json{{"block_id", "B1"}, {"inst_id", "I1"}}},
+        {           "predicate",
+         nlohmann::json{{"expr",
+         nlohmann::json{{"op", "sink.marker"},
+         {"args", nlohmann::json::array({"UB.DivZero"})}}},
+         {"pretty", "sink.marker"}}                                                         }
+    };
+
+    return nlohmann::json{
+        {"schema_version",                                                 "po.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {         "tu_id",                                        make_sha256('a')},
+        {           "pos",                             nlohmann::json::array({po})}
+    };
+}
+
+nlohmann::json make_contract_snapshot()
+{
+    nlohmann::json contracts = nlohmann::json::array();
+    contracts.push_back(nlohmann::json{
+        {"schema_version",                        "contract_ir.v1"                          },
+        {   "contract_id",                                                  make_sha256('d')},
+        {        "target",                               nlohmann::json{{"usr", "usr::foo"}}},
+        {          "tier",                                                           "Tier1"},
+        { "version_scope",
+         nlohmann::json{{"abi", "x86_64"},
+         {"library_version", "1.0.0"},
+         {"conditions", nlohmann::json::array()},
+         {"priority", 0}}                                                                   },
+        {      "contract",
+         nlohmann::json{
+         {"pre",
+         nlohmann::json{{"expr", nlohmann::json{{"op", "true"}}}, {"pretty", "true"}}}}     }
+    });
+
+    return nlohmann::json{
+        {"schema_version",                                    "specdb_snapshot.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {     "contracts",                                               contracts}
+    };
+}
+
+}  // namespace
+
+TEST(AnalyzerBudgetTest, BudgetExceededProducesUnknown)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_budget_exceeded");
+    auto cert_dir = temp_dir / "certstore";
+
+    AnalyzerConfig::AnalysisBudget budget{};
+    budget.max_iterations = 1;
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"},
+        .budget = budget,
+        .memory_domain = ""
+    });
+
+    auto nir = make_nir_with_two_blocks();
+    auto po_list = make_po_list();
+    auto specdb_snapshot = make_contract_snapshot();
+
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    ASSERT_EQ(unknowns.size(), 1U);
+    EXPECT_EQ(unknowns.at(0).at("unknown_code"), "BudgetExceeded");
+    const auto& action = unknowns.at(0).at("refinement_plan").at("actions").at(0).at("action");
+    EXPECT_EQ(action, "increase-budget");
+}
+
+}  // namespace sappp::analyzer::test

--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -578,7 +578,9 @@ TEST(AnalyzerContractTest, UseAfterLifetimeWithDtorProducesBug)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_lifetime_dtor();
@@ -609,7 +611,9 @@ TEST(AnalyzerContractTest, UseAfterLifetimeAfterMoveIsUnknown)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_lifetime_move();

--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -469,7 +469,9 @@ TEST(AnalyzerContractTest, AddsContractRefsAndKeepsUnknownDetails)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir();
@@ -515,7 +517,9 @@ TEST(AnalyzerContractTest, MissingContractProducesUnknownCode)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir();
@@ -541,7 +545,9 @@ TEST(AnalyzerContractTest, UseAfterLifetimeProducesBug)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_lifetime();
@@ -628,7 +634,9 @@ TEST(AnalyzerContractTest, DoubleFreePoProducesBug)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_heap_double_free();
@@ -659,7 +667,9 @@ TEST(AnalyzerContractTest, InvalidFreePoProducesBug)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_heap_invalid_free();
@@ -690,7 +700,9 @@ TEST(AnalyzerContractTest, UninitReadPoProducesInitUnknown)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir();
@@ -715,7 +727,9 @@ TEST(AnalyzerContractTest, VCallMissingContractProducesUnknownCode)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_vcall("usr::vcall_target");

--- a/tests/analyzer/test_analyzer_points_to.cpp
+++ b/tests/analyzer/test_analyzer_points_to.cpp
@@ -163,7 +163,9 @@ TEST(AnalyzerPointsToTest, PointsToSimpleResolvesNullDeref)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_points_to();

--- a/tests/analyzer/test_analyzer_unknown_codes.cpp
+++ b/tests/analyzer/test_analyzer_unknown_codes.cpp
@@ -171,7 +171,9 @@ Analyzer make_analyzer(const std::filesystem::path& cert_dir)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 }
 

--- a/tools/sappp/main.cpp
+++ b/tools/sappp/main.cpp
@@ -788,6 +788,60 @@ extract_pack_if_needed(const std::filesystem::path& input_path)
     return config_json;
 }
 
+[[nodiscard]] std::optional<std::uint64_t> parse_budget_value(const nlohmann::json& budget,
+                                                              std::string_view key)
+{
+    if (!budget.contains(key)) {
+        return std::nullopt;
+    }
+    const auto& value = budget.at(key);
+    if (value.is_number_unsigned()) {
+        return value.get<std::uint64_t>();
+    }
+    if (value.is_number_integer()) {
+        const auto signed_value = value.get<std::int64_t>();
+        if (signed_value >= 0) {
+            return static_cast<std::uint64_t>(signed_value);
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] sappp::analyzer::AnalyzerConfig::AnalysisBudget
+parse_analysis_budget(const nlohmann::json& analysis_config)
+{
+    sappp::analyzer::AnalyzerConfig::AnalysisBudget budget;
+    if (!analysis_config.contains("analysis") || !analysis_config.at("analysis").is_object()) {
+        return budget;
+    }
+    const auto& analysis = analysis_config.at("analysis");
+    if (!analysis.contains("budget") || !analysis.at("budget").is_object()) {
+        return budget;
+    }
+    const auto& budget_json = analysis.at("budget");
+    budget.max_iterations = parse_budget_value(budget_json, "max_iterations");
+    budget.max_states = parse_budget_value(budget_json, "max_states");
+    budget.max_summary_nodes = parse_budget_value(budget_json, "max_summary_nodes");
+    budget.max_time_ms = parse_budget_value(budget_json, "max_time_ms");
+    return budget;
+}
+
+[[nodiscard]] std::optional<std::string> parse_memory_domain(const nlohmann::json& analysis_config)
+{
+    if (!analysis_config.contains("analysis") || !analysis_config.at("analysis").is_object()) {
+        return std::nullopt;
+    }
+    const auto& analysis = analysis_config.at("analysis");
+    if (!analysis.contains("domains") || !analysis.at("domains").is_object()) {
+        return std::nullopt;
+    }
+    const auto& domains = analysis.at("domains");
+    if (!domains.contains("memory") || !domains.at("memory").is_string()) {
+        return std::nullopt;
+    }
+    return domains.at("memory").get<std::string>();
+}
+
 [[nodiscard]] sappp::Result<nlohmann::json>
 load_specdb_snapshot(const AnalyzeOptions& options,
                      std::string_view generated_at,
@@ -803,9 +857,10 @@ load_specdb_snapshot(const AnalyzeOptions& options,
     return sappp::specdb::build_snapshot(specdb_options);
 }
 
-[[nodiscard]] sappp::VoidResult write_analysis_config_output(const AnalyzePaths& paths,
-                                                             const AnalyzeOptions& options,
-                                                             std::string_view generated_at)
+[[nodiscard]] sappp::Result<nlohmann::json>
+write_analysis_config_output(const AnalyzePaths& paths,
+                             const AnalyzeOptions& options,
+                             std::string_view generated_at)
 {
     auto analysis_config = load_analysis_config(options, generated_at);
     if (!analysis_config) {
@@ -815,7 +870,7 @@ load_specdb_snapshot(const AnalyzeOptions& options,
         !write) {
         return std::unexpected(write.error());
     }
-    return {};
+    return *analysis_config;
 }
 
 [[nodiscard]] sappp::VoidResult write_specdb_snapshot_output(const AnalyzePaths& paths,
@@ -1617,10 +1672,10 @@ load_specdb_snapshot(const AnalyzeOptions& options,
     }
 
     const std::string generated_at = generated_at_from_json(*snapshot_json);
-    if (auto write_result = write_analysis_config_output(*paths, options, generated_at);
-        !write_result) {
-        std::println(stderr, "Error: analysis_config failed: {}", write_result.error().message);
-        return exit_code_for_error(write_result.error());
+    auto analysis_config = write_analysis_config_output(*paths, options, generated_at);
+    if (!analysis_config) {
+        std::println(stderr, "Error: analysis_config failed: {}", analysis_config.error().message);
+        return exit_code_for_error(analysis_config.error());
     }
     if (auto write_result =
             write_specdb_snapshot_output(*paths, options, generated_at, *snapshot_json);
@@ -1635,9 +1690,13 @@ load_specdb_snapshot(const AnalyzeOptions& options,
                      specdb_snapshot_json.error().message);
         return exit_code_for_error(specdb_snapshot_json.error());
     }
+    auto analysis_budget = parse_analysis_budget(*analysis_config);
+    auto memory_domain = parse_memory_domain(*analysis_config);
     sappp::analyzer::Analyzer analyzer({.schema_dir = options.schema_dir,
                                         .certstore_dir = paths->certstore_dir.string(),
-                                        .versions = options.versions});
+                                        .versions = options.versions,
+                                        .budget = analysis_budget,
+                                        .memory_domain = memory_domain});
     auto analyzer_output = analyzer.analyze(result->nir, *po_list_result, &*specdb_snapshot_json);
     if (!analyzer_output) {
         std::println(stderr, "Error: analyzer failed: {}", analyzer_output.error().message);


### PR DESCRIPTION
## 概要
- analysis_config の budget を解析器に連携し、超過時に UNKNOWN を BudgetExceeded として記録
- points-to 証拠の domain 選択に memory ドメイン設定を反映
- 予算超過のユニットテストを追加

## 変更点
- AnalyzerConfig に budget/memory_domain を追加
- 予算トラッキングと BudgetExceeded unknown を実装
- analyzer テストに BudgetExceeded ケースを追加

## テスト
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure
- ctest --test-dir build -R determinism --output-on-failure

Closes #76