### PR TITLE
例外フローの最小意味論を実装

### DIFF
--- a/tests/end_to_end/litmus_exception_raii.cpp
+++ b/tests/end_to_end/litmus_exception_raii.cpp
@@ -18,6 +18,11 @@ int main()
         sappp_check("shift", false);
         throw 1;
     } catch (...) {
-        return 0;
+        try {
+            Guard handler_guard;
+            throw;
+        } catch (...) {
+            return 0;
+        }
     }
 }

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -401,7 +401,7 @@ TEST(LitmusE2E, ExceptionRaii)
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_exception_raii.cpp",
         .expected_po_kinds = {"UB.Shift"},
         .expected_categories = {"SAFE"},
-        .required_ops = {"invoke", "throw", "landingpad", "dtor"},
+        .required_ops = {"invoke", "throw", "landingpad", "resume", "dtor"},
         .required_edge_kinds = {"exception"},
         .require_vcall_candidates = false,
         .expected_unknown_codes = {},


### PR DESCRIPTION
## 概要
- Analyzerの例外エッジ伝播とinvoke/throw/resume境界処理を追加
- ExceptionFlowConservativeは未モデリング時のみ発火するよう調整
- RAII例外テストにrethrowを追加しresumeを確認

Fixes #78