### PR TITLE
Initドメイン: UninitReadをBUG/SAFE判定へ

### DIFF
--- a/libs/frontend_clang/frontend.cpp
+++ b/libs/frontend_clang/frontend.cpp
@@ -924,7 +924,9 @@ std::optional<ClassifiedStmt> classify_assign_stmt(const clang::Stmt* stmt)
     std::vector<nlohmann::json> args;
     for (const auto* decl : decl_stmt->decls()) {
         if (const auto* var_decl = clang::dyn_cast<clang::VarDecl>(decl)) {
-            args.push_back(build_ref_from_decl(var_decl));
+            nlohmann::json ref = build_ref_from_decl(var_decl);
+            ref["has_init"] = var_decl->hasInit();
+            args.push_back(std::move(ref));
         }
     }
     if (args.empty()) {

--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -419,6 +419,7 @@ nlohmann::json make_invalid_free_po_list()
     };
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): Test helper keeps call sites compact.
 nlohmann::json make_po_list_for_function(std::string_view function_usr,
                                          std::string_view mangled_name,
                                          std::string_view block_id,
@@ -452,6 +453,7 @@ nlohmann::json make_po_list_for_function(std::string_view function_usr,
     };
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters): Test helper keeps call sites compact.
 nlohmann::json make_use_after_lifetime_po_list_for_target(std::string_view target,
                                                           std::string_view inst_id)
 {
@@ -852,7 +854,9 @@ TEST(AnalyzerContractTest, UninitReadPoProducesSafe)
         .certstore_dir = cert_dir.string(),
         .versions = {.semantics = "sem.v1",
                      .proof_system = "proof.v1",
-                     .profile = "safety.core.v1"}
+                     .profile = "safety.core.v1"},
+        .budget = AnalyzerConfig::AnalysisBudget{},
+        .memory_domain = ""
     });
 
     auto nir = make_nir_with_uninit_read_safe();

--- a/tests/end_to_end/litmus_uninit_read.cpp
+++ b/tests/end_to_end/litmus_uninit_read.cpp
@@ -1,5 +1,5 @@
 // Litmus test: Uninitialized read
-// Expected: UNKNOWN (UninitRead)
+// Expected: BUG (UninitRead)
 
 void sappp_sink(const char* kind);
 

--- a/tests/end_to_end/test_litmus_e2e.cpp
+++ b/tests/end_to_end/test_litmus_e2e.cpp
@@ -386,7 +386,7 @@ TEST(LitmusE2E, UninitRead)
         .name = "uninit_read",
         .source_path = fs::path(SAPPP_REPO_ROOT) / "tests/end_to_end/litmus_uninit_read.cpp",
         .expected_po_kinds = {"UninitRead"},
-        .expected_categories = {"UNKNOWN"},
+        .expected_categories = {"BUG"},
         .required_ops = {},
         .required_edge_kinds = {},
         .require_vcall_candidates = false,


### PR DESCRIPTION
## 概要\n- init状態の抽象解釈を追加し、UninitReadをBUG/SAFE/UNKNOWNで判定\n- assignのrefにhas_initを付与して宣言初期化の有無を伝搬\n- UninitReadのlitmus/ユニットテスト期待値を更新\n\n## テスト\n- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n- cmake --build build --parallel\n- ctest --test-dir build --output-on-failure\n- ctest --test-dir build -R determinism --output-on-failure\n- cmake -S . -B build-frontend-on -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n- cmake --build build-frontend-on --parallel\n- ctest --test-dir build-frontend-on --output-on-failure\n- ./scripts/agent-final-check.sh --until-ok\n\nCloses #66