### PR TITLE
SpecDB契約マッチングのversion_scope対応

### DIFF
--- a/docs/SAPpp_Detailed_Design_v0.1.md
+++ b/docs/SAPpp_Detailed_Design_v0.1.md
@@ -661,6 +661,7 @@ pack/
 3. `conditions`（フラグ、マクロ、OS等）評価
 
 同率の場合は `priority`（数値）で決定、未指定は 0。
+それでも複数残る場合は `contract_id` で安定ソートし、全てを適用候補として扱う。
 
 #### 5.5.5 Tier 運用
 
@@ -883,4 +884,3 @@ Validator が行うチェック:
 3. IR 正規化のさらなる微小編集耐性（アンカー強化）
 4. 証拠の hash_scope の厳密化（pretty/notes の扱い）
 5. Concurrency/Exception の v1 保守的 UNKNOWN 条件の細分化
-

--- a/libs/analyzer/analyzer.cpp
+++ b/libs/analyzer/analyzer.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>
 #include <deque>
+#include <limits>
 #include <map>
 #include <optional>
 #include <ranges>
@@ -34,12 +35,34 @@ constexpr std::string_view kPointsToOutOfBoundsTarget = "oob";
 constexpr std::size_t kMaxPointsToTargets = 4;
 constexpr std::string_view kDeterministicGeneratedAt = "1970-01-01T00:00:00Z";
 
+// NOLINTBEGIN(cppcoreguidelines-use-default-member-init,modernize-use-default-member-init)
+// - Explicit init keeps -Weffc++ satisfied for POD-style holders.
+struct VersionScopeInfo
+{
+    std::string abi;
+    std::string library_version;
+    std::vector<std::string> conditions;
+    int priority;
+
+    VersionScopeInfo()
+        // NOLINTNEXTLINE(readability-redundant-member-init) - required for -Weffc++.
+        : abi()
+        // NOLINTNEXTLINE(readability-redundant-member-init)
+        , library_version()
+        // NOLINTNEXTLINE(readability-redundant-member-init)
+        , conditions()
+        , priority(0)
+    {}
+};
+// NOLINTEND(cppcoreguidelines-use-default-member-init,modernize-use-default-member-init)
+
 struct ContractInfo
 {
     std::string contract_id;
     std::string tier;
     std::string target_usr;
     nlohmann::json version_scope;
+    VersionScopeInfo scope;
     bool has_pre = false;
     bool has_post = false;
     bool has_frame = false;
@@ -149,6 +172,65 @@ struct JsonFieldContext
     return &obj.at(key);
 }
 
+// NOLINTNEXTLINE(readability-function-size) - Keep scope validation explicit for diagnostics.
+[[nodiscard]] sappp::Result<VersionScopeInfo> parse_version_scope(const nlohmann::json& contract,
+                                                                  nlohmann::json& normalized_scope)
+{
+    VersionScopeInfo scope;
+    if (!contract.contains("version_scope")) {
+        normalized_scope = nlohmann::json::object();
+        return scope;
+    }
+    if (!contract.at("version_scope").is_object()) {
+        return std::unexpected(
+            sappp::Error::make("InvalidFieldType", "version_scope must be an object in contract"));
+    }
+    normalized_scope = contract.at("version_scope");
+    const auto& scope_obj = contract.at("version_scope");
+
+    if (scope_obj.contains("abi")) {
+        if (!scope_obj.at("abi").is_string()) {
+            return std::unexpected(
+                sappp::Error::make("InvalidFieldType", "version_scope.abi must be a string"));
+        }
+        scope.abi = scope_obj.at("abi").get<std::string>();
+    }
+    if (scope_obj.contains("library_version")) {
+        if (!scope_obj.at("library_version").is_string()) {
+            return std::unexpected(
+                sappp::Error::make("InvalidFieldType",
+                                   "version_scope.library_version must be a string"));
+        }
+        scope.library_version = scope_obj.at("library_version").get<std::string>();
+    }
+    if (scope_obj.contains("priority")) {
+        if (!scope_obj.at("priority").is_number_integer()) {
+            return std::unexpected(
+                sappp::Error::make("InvalidFieldType", "version_scope.priority must be integer"));
+        }
+        scope.priority = scope_obj.at("priority").get<int>();
+    }
+    if (scope_obj.contains("conditions")) {
+        if (!scope_obj.at("conditions").is_array()) {
+            return std::unexpected(
+                sappp::Error::make("InvalidFieldType", "version_scope.conditions must be array"));
+        }
+        for (const auto& entry : scope_obj.at("conditions")) {
+            if (!entry.is_string()) {
+                return std::unexpected(
+                    sappp::Error::make("InvalidFieldType",
+                                       "version_scope.conditions entries must be strings"));
+            }
+            scope.conditions.push_back(entry.get<std::string>());
+        }
+        std::ranges::stable_sort(scope.conditions);
+        auto unique_end = std::ranges::unique(scope.conditions);
+        scope.conditions.erase(unique_end.begin(), unique_end.end());
+        normalized_scope["conditions"] = scope.conditions;
+    }
+    return scope;
+}
+
 [[nodiscard]] sappp::Result<ContractInfo> parse_contract_entry(const nlohmann::json& contract)
 {
     if (!contract.is_object()) {
@@ -176,9 +258,10 @@ struct JsonFieldContext
         return std::unexpected(target_usr.error());
     }
 
-    nlohmann::json version_scope = nlohmann::json::object();
-    if (contract.contains("version_scope") && contract.at("version_scope").is_object()) {
-        version_scope = contract.at("version_scope");
+    nlohmann::json version_scope;
+    auto scope_info = parse_version_scope(contract, version_scope);
+    if (!scope_info) {
+        return std::unexpected(scope_info.error());
     }
 
     bool has_pre = false;
@@ -200,6 +283,7 @@ struct JsonFieldContext
         .tier = std::move(*tier),
         .target_usr = std::move(*target_usr),
         .version_scope = std::move(version_scope),
+        .scope = std::move(*scope_info),
         .has_pre = has_pre,
         .has_post = has_post,
         .has_frame = has_frame,
@@ -254,6 +338,11 @@ using VCallCandidateSetMap = std::map<std::string, std::vector<std::string>>;
     return args.at(1).get<std::string>();
 }
 
+[[nodiscard]] std::vector<const ContractInfo*>
+select_contracts_for_target(std::string_view usr,
+                            const ContractIndex& contract_index,
+                            const ContractMatchContext& context);
+
 // NOLINTNEXTLINE(readability-function-size) - Parse vcall candidate tables.
 [[nodiscard]] VCallCandidateSetMap collect_vcall_candidate_sets(const nlohmann::json& func)
 {
@@ -287,7 +376,8 @@ using VCallCandidateSetMap = std::map<std::string, std::vector<std::string>>;
 
 // NOLINTNEXTLINE(readability-function-size) - Summarize vcall candidates.
 [[nodiscard]] VCallSummaryMap build_vcall_summary_map(const nlohmann::json& nir_json,
-                                                      const ContractIndex& contract_index)
+                                                      const ContractIndex& contract_index,
+                                                      const ContractMatchContext& context)
 {
     VCallSummaryMap summaries;
     if (!nir_json.contains("functions") || !nir_json.at("functions").is_array()) {
@@ -361,13 +451,11 @@ using VCallCandidateSetMap = std::map<std::string, std::vector<std::string>>;
         summary.candidate_methods.erase(method_unique.begin(), method_unique.end());
 
         for (const auto& method : summary.candidate_methods) {
-            auto contract_it = contract_index.find(method);
             bool has_pre = false;
-            if (contract_it != contract_index.end()) {
-                for (const auto& contract : contract_it->second) {
-                    summary.candidate_contracts.push_back(&contract);
-                    has_pre = has_pre || contract.has_pre;
-                }
+            auto matched_contracts = select_contracts_for_target(method, contract_index, context);
+            for (const auto* contract : matched_contracts) {
+                summary.candidate_contracts.push_back(contract);
+                has_pre = has_pre || contract->has_pre;
             }
             if (!has_pre) {
                 summary.missing_contract_targets.push_back(method);
@@ -458,8 +546,142 @@ struct ContractMatchSummary
     {}
 };
 
+[[nodiscard]] ContractMatchContext normalize_match_context(ContractMatchContext context)
+{
+    std::ranges::stable_sort(context.conditions);
+    auto unique_end = std::ranges::unique(context.conditions);
+    context.conditions.erase(unique_end.begin(), unique_end.end());
+    return context;
+}
+
+[[nodiscard]] bool is_subset_sorted(const std::vector<std::string>& subset,
+                                    const std::vector<std::string>& superset)
+{
+    return std::ranges::includes(superset, subset);
+}
+
+struct ContractMatchCandidate
+{
+    const ContractInfo* contract = nullptr;
+    bool abi_specific = false;
+    bool library_specific = false;
+    std::size_t conditions_specificity = 0;
+};
+
+[[nodiscard]] std::optional<ContractMatchCandidate>
+evaluate_contract_candidate(const ContractInfo& contract, const ContractMatchContext& context)
+{
+    ContractMatchCandidate candidate;
+    candidate.contract = &contract;
+
+    if (!contract.scope.abi.empty()) {
+        if (context.abi.empty() || contract.scope.abi != context.abi) {
+            return std::nullopt;
+        }
+        candidate.abi_specific = true;
+    }
+    if (!contract.scope.library_version.empty()) {
+        if (context.library_version.empty()
+            || contract.scope.library_version != context.library_version) {
+            return std::nullopt;
+        }
+        candidate.library_specific = true;
+    }
+    if (!contract.scope.conditions.empty()) {
+        if (context.conditions.empty()
+            || !is_subset_sorted(contract.scope.conditions, context.conditions)) {
+            return std::nullopt;
+        }
+        candidate.conditions_specificity = contract.scope.conditions.size();
+    }
+    return candidate;
+}
+
+// NOLINTBEGIN(readability-function-size) - Matching rules are explicitly staged.
+[[nodiscard]] std::vector<const ContractInfo*>
+select_contracts_for_target(std::string_view usr,
+                            const ContractIndex& contract_index,
+                            const ContractMatchContext& context)
+{
+    auto it = contract_index.find(std::string(usr));
+    if (it == contract_index.end()) {
+        return {};
+    }
+
+    std::vector<ContractMatchCandidate> candidates;
+    candidates.reserve(it->second.size());
+    for (const auto& contract : it->second) {
+        auto candidate = evaluate_contract_candidate(contract, context);
+        if (!candidate) {
+            continue;
+        }
+        candidates.push_back(*candidate);
+    }
+    if (candidates.empty()) {
+        return {};
+    }
+
+    bool has_specific_abi = std::ranges::any_of(candidates, [](const auto& entry) noexcept {
+        return entry.abi_specific;
+    });
+    if (has_specific_abi) {
+        auto abi_end = std::ranges::remove_if(candidates, [](const auto& entry) noexcept {
+            return !entry.abi_specific;
+        });
+        candidates.erase(abi_end.begin(), abi_end.end());
+    }
+
+    bool has_specific_library = std::ranges::any_of(candidates, [](const auto& entry) noexcept {
+        return entry.library_specific;
+    });
+    if (has_specific_library) {
+        auto lib_end = std::ranges::remove_if(candidates, [](const auto& entry) noexcept {
+            return !entry.library_specific;
+        });
+        candidates.erase(lib_end.begin(), lib_end.end());
+    }
+
+    std::size_t max_conditions = 0;
+    for (const auto& candidate : candidates) {
+        max_conditions = std::max(max_conditions, candidate.conditions_specificity);
+    }
+    if (max_conditions > 0) {
+        auto cond_end = std::ranges::remove_if(candidates, [&](const auto& entry) noexcept {
+            return entry.conditions_specificity != max_conditions;
+        });
+        candidates.erase(cond_end.begin(), cond_end.end());
+    }
+
+    int max_priority = std::numeric_limits<int>::min();
+    for (const auto& candidate : candidates) {
+        max_priority = std::max(max_priority, candidate.contract->scope.priority);
+    }
+    auto priority_end = std::ranges::remove_if(candidates, [&](const auto& entry) noexcept {
+        return entry.contract->scope.priority != max_priority;
+    });
+    candidates.erase(priority_end.begin(), priority_end.end());
+
+    std::vector<const ContractInfo*> matched;
+    matched.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+        matched.push_back(candidate.contract);
+    }
+    std::ranges::stable_sort(matched, [](const ContractInfo* a, const ContractInfo* b) noexcept {
+        return a->contract_id < b->contract_id;
+    });
+    auto unique_end =
+        std::ranges::unique(matched, [](const ContractInfo* a, const ContractInfo* b) noexcept {
+            return a->contract_id == b->contract_id;
+        });
+    matched.erase(unique_end.begin(), matched.end());
+    return matched;
+}
+// NOLINTEND(readability-function-size)
+
 [[nodiscard]] sappp::Result<ContractMatchSummary>
-match_contracts_for_po(const nlohmann::json& po, const ContractIndex& contract_index)
+match_contracts_for_po(const nlohmann::json& po,
+                       const ContractIndex& contract_index,
+                       const ContractMatchContext& context)
 {
     auto function_obj =
         require_object(JsonFieldContext{.obj = &po, .key = "function", .context = "po"});
@@ -473,15 +695,15 @@ match_contracts_for_po(const nlohmann::json& po, const ContractIndex& contract_i
     }
 
     ContractMatchSummary summary;
-    auto it = contract_index.find(*usr);
-    if (it == contract_index.end()) {
+    auto matched = select_contracts_for_target(*usr, contract_index, context);
+    if (matched.empty()) {
         return summary;
     }
-    summary.contracts.reserve(it->second.size());
-    for (const auto& contract : it->second) {
-        summary.contracts.push_back(&contract);
-        summary.has_pre = summary.has_pre || contract.has_pre;
-        summary.has_concurrency = summary.has_concurrency || contract.has_concurrency;
+    summary.contracts.reserve(matched.size());
+    for (const auto* contract : matched) {
+        summary.contracts.push_back(contract);
+        summary.has_pre = summary.has_pre || contract->has_pre;
+        summary.has_concurrency = summary.has_concurrency || contract->has_concurrency;
     }
     return summary;
 }
@@ -823,7 +1045,7 @@ apply_lifetime_block_transfer_with_exception(const LifetimeState& in_state,
     }
 
     for (const auto& inst : block.at("insts")) {
-        std::string_view op = "";
+        std::string_view op;
         if (inst.contains("op") && inst.at("op").is_string()) {
             op = inst.at("op").get_ref<const std::string&>();
         }
@@ -852,6 +1074,7 @@ apply_lifetime_block_transfer_with_exception(const LifetimeState& in_state,
                                   .has_exception_op = has_exception_op};
 }
 
+// NOLINTNEXTLINE(readability-function-size) - Fixpoint iteration needs full context.
 void compute_lifetime_fixpoint(FunctionLifetimeAnalysis& analysis)
 {
     bool changed = true;
@@ -1361,7 +1584,7 @@ apply_points_to_block_transfer_with_exception(const PointsToState& in_state,
     }
 
     for (const auto& inst : block.at("insts")) {
-        std::string_view op = "";
+        std::string_view op;
         if (inst.contains("op") && inst.at("op").is_string()) {
             op = inst.at("op").get_ref<const std::string&>();
         }
@@ -1394,6 +1617,7 @@ apply_points_to_block_transfer_with_exception(const PointsToState& in_state,
                                   .has_exception_op = has_exception_op};
 }
 
+// NOLINTNEXTLINE(readability-function-size) - Fixpoint iteration needs full context.
 [[nodiscard]] sappp::VoidResult compute_points_to_fixpoint(FunctionPointsToAnalysis& analysis)
 {
     bool changed = true;
@@ -1427,6 +1651,7 @@ apply_points_to_block_transfer_with_exception(const PointsToState& in_state,
                 exception_succ_it != analysis.has_exception_successor.end()
                 && exception_succ_it->second) {
                 if (transfer->exception_out.has_value()) {
+                    // NOLINTNEXTLINE(bugprone-unchecked-optional-access) - guarded by has_value.
                     exception_out = std::move(*transfer->exception_out);
                 } else {
                     exception_out = merge_points_to_states(in_state, transfer->normal_out);
@@ -1771,7 +1996,7 @@ apply_heap_block_transfer_with_exception(const HeapLifetimeState& in_state,
     }
 
     for (const auto& inst : block.at("insts")) {
-        std::string_view op = "";
+        std::string_view op;
         if (inst.contains("op") && inst.at("op").is_string()) {
             op = inst.at("op").get_ref<const std::string&>();
         }
@@ -1800,6 +2025,7 @@ apply_heap_block_transfer_with_exception(const HeapLifetimeState& in_state,
                                       .has_exception_op = has_exception_op};
 }
 
+// NOLINTNEXTLINE(readability-function-size) - Fixpoint iteration needs full context.
 void compute_heap_lifetime_fixpoint(FunctionHeapLifetimeAnalysis& analysis)
 {
     bool changed = true;
@@ -2941,6 +3167,7 @@ struct PoProcessingContext
     const std::unordered_map<std::string, std::string>* function_uid_map = nullptr;
     const FunctionFeatureCache* feature_cache = nullptr;
     const ContractIndex* contract_index = nullptr;
+    const ContractMatchContext* match_context = nullptr;
     const VCallSummaryMap* vcall_summaries = nullptr;
     std::unordered_map<std::string, std::string>* contract_ref_cache = nullptr;
     const LifetimeAnalysisCache* lifetime_cache = nullptr;
@@ -3635,7 +3862,10 @@ resolve_contracts(const nlohmann::json& po, const PoProcessingContext& context)
     if (context.contract_index == nullptr) {
         return ContractMatchSummary{};
     }
-    return match_contracts_for_po(po, *context.contract_index);
+    ContractMatchContext fallback;
+    const ContractMatchContext& match_context =
+        context.match_context == nullptr ? fallback : *context.match_context;
+    return match_contracts_for_po(po, *context.contract_index, match_context);
 }
 
 // NOLINTNEXTLINE(readability-function-size) - Aggregates PO artifacts.
@@ -3762,7 +3992,8 @@ Analyzer::Analyzer(AnalyzerConfig config)
 // NOLINTNEXTLINE(readability-function-size) - Top-level analysis.
 sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
                                                const nlohmann::json& po_list_json,
-                                               const nlohmann::json* specdb_snapshot) const
+                                               const nlohmann::json* specdb_snapshot,
+                                               const ContractMatchContext& match_context) const
 {
     auto tu_id =
         require_string(JsonFieldContext{.obj = &nir_json, .key = "tu_id", .context = "nir"});
@@ -3791,7 +4022,9 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
     if (!contract_index) {
         return std::unexpected(contract_index.error());
     }
-    const auto vcall_summaries = build_vcall_summary_map(nir_json, *contract_index);
+    ContractMatchContext normalized_context = normalize_match_context(match_context);
+    const auto vcall_summaries =
+        build_vcall_summary_map(nir_json, *contract_index, normalized_context);
     const auto lifetime_cache = build_lifetime_analysis_cache(nir_json);
     const auto heap_lifetime_cache = build_heap_lifetime_analysis_cache(nir_json);
     auto points_to_cache = build_points_to_analysis_cache(nir_json);
@@ -3808,6 +4041,7 @@ sappp::Result<AnalyzeOutput> Analyzer::analyze(const nlohmann::json& nir_json,
                                 .function_uid_map = &function_uid_map,
                                 .feature_cache = &feature_cache,
                                 .contract_index = &(*contract_index),
+                                .match_context = &normalized_context,
                                 .vcall_summaries = &vcall_summaries,
                                 .contract_ref_cache = &contract_ref_cache,
                                 .lifetime_cache = &lifetime_cache,

--- a/libs/analyzer/analyzer.hpp
+++ b/libs/analyzer/analyzer.hpp
@@ -9,6 +9,7 @@
 #include "sappp/version.hpp"
 
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -26,14 +27,23 @@ struct AnalyzeOutput
     nlohmann::json unknown_ledger;
 };
 
+struct ContractMatchContext
+{
+    std::string abi{};
+    std::string library_version{};
+    std::vector<std::string> conditions{};
+};
+
 class Analyzer
 {
 public:
     explicit Analyzer(AnalyzerConfig config);
 
-    [[nodiscard]] sappp::Result<AnalyzeOutput> analyze(const nlohmann::json& nir_json,
-                                                       const nlohmann::json& po_list_json,
-                                                       const nlohmann::json* specdb_snapshot) const;
+    [[nodiscard]] sappp::Result<AnalyzeOutput>
+    analyze(const nlohmann::json& nir_json,
+            const nlohmann::json& po_list_json,
+            const nlohmann::json* specdb_snapshot,
+            const ContractMatchContext& match_context = ContractMatchContext{}) const;
 
 private:
     AnalyzerConfig m_config;

--- a/tests/analyzer/test_analyzer_contracts.cpp
+++ b/tests/analyzer/test_analyzer_contracts.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -25,6 +26,15 @@ std::filesystem::path ensure_temp_dir(const std::string& name)
     std::filesystem::remove_all(temp_dir, ec);
     std::filesystem::create_directories(temp_dir, ec);
     return temp_dir;
+}
+
+ContractMatchContext make_match_context(std::vector<std::string> conditions = {})
+{
+    ContractMatchContext context;
+    context.abi = "x86_64";
+    context.library_version = "1.0.0";
+    context.conditions = std::move(conditions);
+    return context;
 }
 
 nlohmann::json make_nir()
@@ -457,6 +467,30 @@ nlohmann::json make_contract_snapshot(bool include_contract)
     };
 }
 
+nlohmann::json make_contract_entry(std::string contract_id,
+                                   std::string usr,
+                                   std::string abi,
+                                   std::string library_version,
+                                   std::vector<std::string> conditions,
+                                   int priority)
+{
+    return nlohmann::json{
+        {"schema_version",                        "contract_ir.v1"                          },
+        {   "contract_id",                                            std::move(contract_id)},
+        {        "target",                           nlohmann::json{{"usr", std::move(usr)}}},
+        {          "tier",                                                           "Tier1"},
+        { "version_scope",
+         nlohmann::json{{"abi", std::move(abi)},
+         {"library_version", std::move(library_version)},
+         {"conditions", std::move(conditions)},
+         {"priority", priority}}                                                            },
+        {      "contract",
+         nlohmann::json{
+         {"pre",
+         nlohmann::json{{"expr", nlohmann::json{{"op", "true"}}}, {"pretty", "true"}}}}     }
+    };
+}
+
 }  // namespace
 
 TEST(AnalyzerContractTest, AddsContractRefsAndKeepsUnknownDetails)
@@ -476,7 +510,7 @@ TEST(AnalyzerContractTest, AddsContractRefsAndKeepsUnknownDetails)
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot(true);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -522,7 +556,7 @@ TEST(AnalyzerContractTest, MissingContractProducesUnknownCode)
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot(false);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -548,7 +582,7 @@ TEST(AnalyzerContractTest, UseAfterLifetimeProducesBug)
     auto po_list = make_use_after_lifetime_po_list();
     auto specdb_snapshot = make_contract_snapshot(true);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
@@ -579,7 +613,7 @@ TEST(AnalyzerContractTest, UseAfterLifetimeWithDtorProducesBug)
     auto po_list = make_use_after_lifetime_po_list();
     auto specdb_snapshot = make_contract_snapshot(true);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
@@ -610,7 +644,7 @@ TEST(AnalyzerContractTest, UseAfterLifetimeAfterMoveIsUnknown)
     auto po_list = make_use_after_lifetime_po_list_for_target("moved_from", "I2");
     auto specdb_snapshot = make_contract_snapshot(true);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -635,7 +669,7 @@ TEST(AnalyzerContractTest, DoubleFreePoProducesBug)
     auto po_list = make_double_free_po_list();
     auto specdb_snapshot = make_contract_snapshot(true);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
@@ -666,7 +700,7 @@ TEST(AnalyzerContractTest, InvalidFreePoProducesBug)
     auto po_list = make_invalid_free_po_list();
     auto specdb_snapshot = make_contract_snapshot(true);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     sappp::certstore::CertStore cert_store(cert_dir.string(), SAPPP_SCHEMA_DIR);
@@ -697,12 +731,103 @@ TEST(AnalyzerContractTest, UninitReadPoProducesInitUnknown)
     auto po_list = make_po_list("UninitRead");
     auto specdb_snapshot = make_contract_snapshot(true);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
     ASSERT_EQ(unknowns.size(), 1U);
     EXPECT_EQ(unknowns.at(0).at("unknown_code"), "DomainTooWeak.Memory");
+}
+
+TEST(AnalyzerContractTest, MatchContractsRespectsConditionsSpecificity)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_contract_match_conditions");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    nlohmann::json contracts = nlohmann::json::array();
+    contracts.push_back(make_contract_entry(make_sha256('d'),
+                                            "usr::foo",
+                                            "x86_64",
+                                            "1.0.0",
+                                            {"COND_A", "COND_B"},
+                                            1));
+    contracts.push_back(
+        make_contract_entry(make_sha256('e'), "usr::foo", "x86_64", "1.0.0", {"COND_A"}, 5));
+    contracts.push_back(
+        make_contract_entry(make_sha256('f'), "usr::foo", "x86_64", "1.0.0", {}, 10));
+    contracts.push_back(make_contract_entry(make_sha256('g'),
+                                            "usr::foo",
+                                            "arm64",
+                                            "1.0.0",
+                                            {"COND_A", "COND_B"},
+                                            0));
+
+    nlohmann::json specdb_snapshot = {
+        {"schema_version",                                    "specdb_snapshot.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {     "contracts",                                               contracts}
+    };
+
+    auto nir = make_nir();
+    auto po_list = make_po_list("UB.DivZero");
+    auto output =
+        analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context({"COND_A", "COND_B"}));
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    ASSERT_EQ(unknowns.size(), 1U);
+    const auto& depends = unknowns.at(0).at("depends_on");
+    const auto& matched_contracts = depends.at("contracts");
+    ASSERT_EQ(matched_contracts.size(), 1U);
+    EXPECT_EQ(matched_contracts.at(0).get<std::string>(), make_sha256('d'));
+}
+
+TEST(AnalyzerContractTest, MatchContractsUsesPriorityAfterScope)
+{
+    auto temp_dir = ensure_temp_dir("sappp_analyzer_contract_match_priority");
+    auto cert_dir = temp_dir / "certstore";
+
+    Analyzer analyzer({
+        .schema_dir = SAPPP_SCHEMA_DIR,
+        .certstore_dir = cert_dir.string(),
+        .versions = {.semantics = "sem.v1",
+                     .proof_system = "proof.v1",
+                     .profile = "safety.core.v1"}
+    });
+
+    nlohmann::json contracts = nlohmann::json::array();
+    contracts.push_back(
+        make_contract_entry(make_sha256('h'), "usr::foo", "x86_64", "1.0.0", {"COND_X"}, 1));
+    contracts.push_back(
+        make_contract_entry(make_sha256('i'), "usr::foo", "x86_64", "1.0.0", {"COND_X"}, 7));
+
+    nlohmann::json specdb_snapshot = {
+        {"schema_version",                                    "specdb_snapshot.v1"},
+        {          "tool", nlohmann::json{{"name", "sappp"}, {"version", "0.1.0"}}},
+        {  "generated_at",                                  "1970-01-01T00:00:00Z"},
+        {     "contracts",                                               contracts}
+    };
+
+    auto nir = make_nir();
+    auto po_list = make_po_list("UB.DivZero");
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context({"COND_X"}));
+    ASSERT_TRUE(output);
+
+    const auto& unknowns = output->unknown_ledger.at("unknowns");
+    ASSERT_EQ(unknowns.size(), 1U);
+    const auto& depends = unknowns.at(0).at("depends_on");
+    const auto& matched_contracts = depends.at("contracts");
+    ASSERT_EQ(matched_contracts.size(), 1U);
+    EXPECT_EQ(matched_contracts.at(0).get<std::string>(), make_sha256('i'));
 }
 
 TEST(AnalyzerContractTest, VCallMissingContractProducesUnknownCode)
@@ -722,7 +847,7 @@ TEST(AnalyzerContractTest, VCallMissingContractProducesUnknownCode)
     auto po_list = make_po_list_for_function("usr::caller", "_Z6callerv", "B1", "I0");
     auto specdb_snapshot = make_contract_snapshot_for_target("usr::caller");
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");

--- a/tests/analyzer/test_analyzer_points_to.cpp
+++ b/tests/analyzer/test_analyzer_points_to.cpp
@@ -26,6 +26,14 @@ std::filesystem::path ensure_temp_dir(const std::string& name)
     return temp_dir;
 }
 
+ContractMatchContext make_match_context()
+{
+    ContractMatchContext context;
+    context.abi = "x86_64";
+    context.library_version = "1.0.0";
+    return context;
+}
+
 nlohmann::json make_nir_with_points_to()
 {
     nlohmann::json safe_inst = {
@@ -170,7 +178,7 @@ TEST(AnalyzerPointsToTest, PointsToSimpleResolvesNullDeref)
     auto po_list = make_po_list_with_points_to();
     auto specdb_snapshot = make_contract_snapshot_for_safe();
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");

--- a/tests/analyzer/test_analyzer_unknown_codes.cpp
+++ b/tests/analyzer/test_analyzer_unknown_codes.cpp
@@ -175,6 +175,14 @@ Analyzer make_analyzer(const std::filesystem::path& cert_dir)
     });
 }
 
+ContractMatchContext make_match_context()
+{
+    ContractMatchContext context;
+    context.abi = "x86_64";
+    context.library_version = "1.0.0";
+    return context;
+}
+
 void expect_unknown_code(const nlohmann::json& unknowns,
                          std::string_view expected_code,
                          std::string_view expected_action)
@@ -202,7 +210,7 @@ TEST(AnalyzerUnknownCodeTest, ExceptionFlowConservativeForUnmodeledExceptionEdge
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot();
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -219,7 +227,7 @@ TEST(AnalyzerUnknownCodeTest, VirtualDispatchUnknownForVcallMissingCandidates)
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot();
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -241,7 +249,7 @@ TEST(AnalyzerUnknownCodeTest, NumericUnknownWithVcallCandidates)
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot(false, {"_Z3barv"});
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -258,7 +266,7 @@ TEST(AnalyzerUnknownCodeTest, AtomicOrderUnknownForAtomicRead)
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot();
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -275,7 +283,7 @@ TEST(AnalyzerUnknownCodeTest, ConcurrencyUnsupportedForThreadSpawn)
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot();
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");
@@ -292,7 +300,7 @@ TEST(AnalyzerUnknownCodeTest, SyncContractMissingForSyncEvent)
     auto po_list = make_po_list("UB.DivZero");
     auto specdb_snapshot = make_contract_snapshot(false);
 
-    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot);
+    auto output = analyzer.analyze(nir, po_list, &specdb_snapshot, make_match_context());
     ASSERT_TRUE(output);
 
     const auto& unknowns = output->unknown_ledger.at("unknowns");


### PR DESCRIPTION
Analyzerにversion_scope/priority条件のマッチングを実装し、CLIからABI文脈を注入。

条件特異性・優先度のテストを追加し、決定性のtie-breakを文書化。