### PR TITLE
Add sem.v1 semantics doc and pack inclusion; fix validator unwind search (ranges)

### DIFF
--- a/docs/SAPpp_Design_Addons_v0.1/ADR/ADR-0103-semantics-version-and-litmus.md
+++ b/docs/SAPpp_Design_Addons_v0.1/ADR/ADR-0103-semantics-version-and-litmus.md
@@ -1,6 +1,6 @@
 # ADR-0103: semantics_version sem.v1 のベースライン規格と逸脱点リスト + litmus 配布
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-01-17
 
 ## Context
@@ -12,9 +12,10 @@ SRS は semantics_version を「文章 + 最小例（litmus）」で固定し、
 2. ベースラインを C++17 に固定（実装容易）し、将来 sem.v2 で更新
 3. コンパイラ/標準ライブラリ差分を含めて“実装定義寄り”にする
 
-## Decision (TBD)
-- Milestone A では最小限の sem.v1.md を pack に含める。
-- sem.v1 の基準規格、逸脱点一覧、litmusセットのフォーマットと格納場所を確定する。
+## Decision
+- sem.v1 の基準規格と逸脱点一覧を `docs/sem.v1.md` に記述する。
+- `sappp pack` は `pack/semantics/sem.v1.md` に同ドキュメントを同梱する。
+- litmus セットは `tests/end_to_end/` 配下に配置し、寿命/例外/仮想の最小例を含める。
 
 ## Consequences
 - 逸脱点に起因する場合は UNKNOWN に倒すルールが明確になる。

--- a/docs/SAPpp_Detailed_Design_v0.1.md
+++ b/docs/SAPpp_Detailed_Design_v0.1.md
@@ -403,7 +403,7 @@ pack/
   specdb/
     snapshot.json
   semantics/
-    sem.v1.md  # 参照用（将来はlitmus含む）
+    sem.v1.md  # 基準規格・逸脱点・litmus一覧を含む意味論ドキュメント
   results/
     validated_results.json
   config/

--- a/docs/sem.v1.md
+++ b/docs/sem.v1.md
@@ -1,0 +1,74 @@
+# sem.v1 — SAP++ Semantics (v1)
+
+このドキュメントは、SAP++ の `sem.v1` における **基準規格** と **逸脱点** を明文化し、
+SAFE/BUG/UNKNOWN の意味論を固定するための規格書です。
+
+> 参照: SRS v1.1 REQ-SEM-001..004
+
+---
+
+## 1. 目的と適用範囲
+
+- `sem.v1` は、SAP++ の解析・検証結果の意味論を固定するための **文章 + litmus** です。
+- 本文書は、再現パックに同梱される `sem.v1.md` と同一内容であることを前提とします。
+
+---
+
+## 2. 基準規格（Baseline）
+
+`sem.v1` の基準規格は以下とします。
+
+- **言語規格**: ISO C++23
+- **ツールチェーン依存**:
+  - フロントエンドは Clang 系を前提（`clang/clang++ -std=c++23`）とし、
+    具体的なターゲット・ABI・標準ライブラリ実装に依存する挙動は **明示的に逸脱点として扱う**。
+
+> 重要: ABI/標準ライブラリ差分に依存する結論（SAFE/BUG）を正当化できない場合、
+> 必ず UNKNOWN に降格する。
+
+---
+
+## 3. 逸脱点一覧（UNKNOWN への降格条件）
+
+以下は、基準規格（C++23）に対する **意図的な抽象化/未対応/簡略化** の一覧です。
+各項目に該当する場合、検証は **UNKNOWN へ降格**します。
+
+| ID | 逸脱点 | UNKNOWN へ倒す条件（運用粒度） |
+| --- | --- | --- |
+| DEV-SEM-001 | 並行性・アトミクスの未対応 | `std::thread`/atomic/happens-before 等の並行性意味論に依存する場合。`ConcurrencyUnsupported`/`AtomicOrderUnknown`/`SyncContractMissing` を目安。 |
+| DEV-SEM-002 | provenance の粗粒度 | pointer-int 変換、広域な pointer 算術、provenance 保持に依存する UB を正当化できない場合。 |
+| DEV-SEM-003 | 例外ランタイムの詳細未モデル化 | `noexcept`/`std::terminate`/例外仕様/ABI 依存の unwind など、ランタイム仕様に依存する場合。例外制御フローのみの抽象で結論できない時は UNKNOWN。 |
+| DEV-SEM-004 | 仮想ディスパッチの候補集合の保守的扱い | 動的型の特定や候補集合の完全性が必要な証明。`VirtualDispatchUnknown`/`VirtualCall.MissingContract.Pre` を目安。 |
+| DEV-SEM-005 | 寿命モデルの対象限定 | placement new / union 活性メンバ / coroutine / setjmp-longjmp など、寿命規則が複雑なケースに依存する場合。 |
+| DEV-SEM-006 | ABI/標準ライブラリ差分 | 標準ライブラリ実装差分・ABI差分に依存する挙動を SAFE/BUG の根拠にできない場合。 |
+
+> 注: UNKNOWN へ倒す際のコードは `unknown.v1` の `unknown_code` に記録する。
+
+---
+
+## 4. Litmus セット（最小例）
+
+以下は `sem.v1` の litmus セットです。**各カテゴリ最低1例**を満たすことを保証します。
+
+| カテゴリ | Litmus | 期待される観測点 | ファイル |
+| --- | --- | --- | --- |
+| 寿命（lifetime） | Use-after-lifetime | `UseAfterLifetime` PO が生成され、BUG で確定できること | `tests/end_to_end/litmus_use_after_lifetime.cpp` |
+| 例外（exception） | Exception + RAII | `invoke/landingpad/resume` 等の例外制御フローが NIR に現れること | `tests/end_to_end/litmus_exception_raii.cpp` |
+| 仮想（virtual） | Virtual call | `vcall` と候補集合が NIR に現れること。候補不足は UNKNOWN として記録 | `tests/end_to_end/litmus_vcall.cpp` |
+
+追加の litmus（UB 系や未初期化など）は `tests/end_to_end/` に継続的に追加する。
+
+---
+
+## 5. pack 同梱の扱い
+
+- `sappp pack` は `sem.v1.md` を `pack/semantics/sem.v1.md` に同梱する。
+- 本ドキュメントが同梱されることにより、解析結果の意味論を再現パックから参照できる。
+
+---
+
+## 6. 更新方針
+
+- `sem.v1` の変更は **破壊的変更** として扱い、変更理由と影響範囲を明記する。
+- 実装が逸脱点を解消した場合は、逸脱点一覧から削除し、
+  対応する litmus と UNKNOWN コードの更新を行う。

--- a/libs/validator/validator.cpp
+++ b/libs/validator/validator.cpp
@@ -753,11 +753,11 @@ validate_trace_transition(const TraceStepInfo& previous,
         if (call_stack.empty()) {
             return proof_failed_error("BugTrace unwind without call frame");
         }
-        auto match_it =
-            std::find_if(call_stack.rbegin(), call_stack.rend(), [&](const CallFrame& frame) {
-                return frame.function_uid == current.function_uid;
-            });
-        if (match_it == call_stack.rend()) {
+        auto reversed_call_stack = call_stack | std::views::reverse;
+        auto match_it = std::ranges::find_if(reversed_call_stack, [&](const CallFrame& frame) {
+            return frame.function_uid == current.function_uid;
+        });
+        if (match_it == std::ranges::end(reversed_call_stack)) {
             return proof_failed_error("BugTrace unwind target mismatch");
         }
         while (!call_stack.empty() && call_stack.back().function_uid != current.function_uid) {

--- a/tools/sappp/main.cpp
+++ b/tools/sappp/main.cpp
@@ -1949,7 +1949,17 @@ write_analysis_config_output(const AnalyzePaths& paths,
         std::println(stderr, "Error: {}", result.error().message);
         return exit_code_for_error(result.error());
     }
-    {
+    const std::filesystem::path semantics_source =
+        std::filesystem::current_path() / "docs" / "sem.v1.md";
+    if (std::filesystem::exists(semantics_source)) {
+        if (auto copied = copy_file_checked(semantics_source, semantics_path); !copied) {
+            std::println(stderr, "Error: {}", copied.error().message);
+            return exit_code_for_error(copied.error());
+        }
+    } else {
+        std::println(stderr,
+                     "Warning: semantics document not found at {}; writing placeholder",
+                     semantics_source.string());
         std::ofstream out(semantics_path);
         if (!out) {
             std::println(stderr, "Error: failed to write semantics stub");


### PR DESCRIPTION
### Motivation
- Stabilize and document the tool semantics for `sem.v1` (baseline and allowed deviations) and ship a minimal litmus set so SAFE/BUG/UNKNOWN meaning is reproducible and referenceable from packs per SRS REQ-SEM-*.
- Ensure `sappp pack` includes the canonical semantics document in `pack/semantics/sem.v1.md` so analysis results carry their semantics metadata for reproducibility.
- Address a `clang-tidy` modernization warning in the validator unwind search by using ranges to satisfy static-analysis rules.

### Description
- Added `docs/sem.v1.md` describing the `sem.v1` baseline (ISO C++23), a concrete list of semantics deviations that must lead to UNKNOWN, and a minimal litmus set (lifetime/exception/virtual) referencing `tests/end_to_end` litmuses.
- Updated `tools/sappp/main.cpp` to include `docs/sem.v1.md` into produced packs (copy if present, otherwise fall back to the existing placeholder), and record its digest in the manifest.
- Fixed `libs/validator/validator.cpp` to use a ranges-based reverse search for unwind matching (`std::views::reverse` + `std::ranges::find_if`) to satisfy `clang-tidy` modernization suggestions and reduce warnings-as-errors issues.
- Updated ADR and design docs to reflect the decision and pack layout: `docs/SAPpp_Design_Addons_v0.1/ADR/ADR-0103-semantics-version-and-litmus.md` (Decision -> Accepted) and `docs/SAPpp_Detailed_Design_v0.1.md` (note that `sem.v1.md` contains baseline/ deviations/ litmus).

### Testing
- Ran configure and build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON` and `cmake --build build --parallel`, which completed successfully (produced `sappp` and test binaries).
- Ran unit/integration tests with `ctest --test-dir build --output-on-failure` and determinism tests with `ctest --test-dir build -R determinism --output-on-failure`; all tests passed (88 tests passed, 0 failed) though one determinism E2E test (`EndToEndDeterminism.Jobs1And8ProduceSameIdsAndDigest`) was skipped per environment.
- Ran static checks and linters: `clang-format` was applied to changed files and `clang-tidy -p build` initially reported a ranges-modernize warning which led to the validator change; after the fix `clang-tidy` completed without treating warnings-as-errors for the modified files in the build environment used.
- Ran repository pre-commit check `./scripts/pre-commit-check.sh`; it ran most checks but reported environment/tooling gaps: `g++-14` not found (GCC build step skipped/failed) and `ajv-cli` not found (schema validation step failed), so the pre-commit script did not fully succeed in this environment.  All local build/test steps performed above succeeded except those requiring the missing external tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778a65d00c832dbc72e0684646b5c2)