### PR TITLE
clang-tidy: fix modernize-use-ranges in validator unwind handling

### DIFF
--- a/libs/validator/validator.cpp
+++ b/libs/validator/validator.cpp
@@ -753,11 +753,11 @@ validate_trace_transition(const TraceStepInfo& previous,
         if (call_stack.empty()) {
             return proof_failed_error("BugTrace unwind without call frame");
         }
-        auto match_it =
-            std::find_if(call_stack.rbegin(), call_stack.rend(), [&](const CallFrame& frame) {
-                return frame.function_uid == current.function_uid;
-            });
-        if (match_it == call_stack.rend()) {
+        auto reversed_call_stack = call_stack | std::views::reverse;
+        auto match_it = std::ranges::find_if(reversed_call_stack, [&](const CallFrame& frame) {
+            return frame.function_uid == current.function_uid;
+        });
+        if (match_it == reversed_call_stack.end()) {
             return proof_failed_error("BugTrace unwind target mismatch");
         }
         while (!call_stack.empty() && call_stack.back().function_uid != current.function_uid) {


### PR DESCRIPTION
### Motivation
- clang-tidy の `modernize-use-ranges` 警告を解消して静的解析を通すため、BugTrace の巻き戻し処理を範囲ベースのアルゴリズムに置換しました。

### Description
- `libs/validator/validator.cpp` の BugTrace unwind 分岐で `std::find_if` と逆イテレータを使う実装を `std::views::reverse` と `std::ranges::find_if` に置き換えました。

### Testing
- 自動化チェックとして `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON`, `cmake --build build --parallel`, `./scripts/run-clang-tidy.sh libs/validator/validator.cpp`, `ctest --test-dir build --output-on-failure` および `ctest --test-dir build -R determinism --output-on-failure` を実行して成功し、ただし `./scripts/pre-commit-check.sh` は環境に `g++-14` と `ajv-cli` が無いため失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778b25cea8832d9b97e45476c25741)