### PR TITLE
Align exception edge modeling with boundary ops and avoid exception-flow UNKNOWNs

### DIFF
--- a/libs/frontend_clang/frontend.cpp
+++ b/libs/frontend_clang/frontend.cpp
@@ -1240,10 +1240,11 @@ ExceptionFlowKind classify_exception_flow(const clang::CFGBlock* block)
     for (const auto& element : *block) {
         if (const auto stmt_elem = element.getAs<clang::CFGStmt>()) {
             const clang::Stmt* stmt = stmt_elem->getStmt();
-            if (!has_throw && stmt_has_throw(stmt)) {
+            const auto classified = classify_stmt(stmt);
+            if (!has_throw && (classified.op == "throw" || classified.op == "resume")) {
                 has_throw = true;
             }
-            if (!has_invoke && stmt_has_throwing_call(stmt)) {
+            if (!has_invoke && classified.op == "invoke") {
                 has_invoke = true;
             }
         }


### PR DESCRIPTION
### Motivation
- Ensure exception-edge generation in the frontend is consistent with the actual exception-boundary operations emitted into the NIR so exception edges map to blocks that contain the corresponding boundary op. 
- Avoid conservative UNKNOWNs in the analyzer when exception edges are present but an exception-boundary op (invoke/throw/resume/landingpad) actually exists in the same block. 
- Add tests to verify exception-path state propagation and the UNKNOWN-avoidance case.

### Description
- Frontend: updated `classify_exception_flow` in `libs/frontend_clang/frontend.cpp` to use the existing `classify_stmt` result (checking for `invoke`/`throw`/`resume`) when deciding a block's exception flow, ensuring boundary ops and generated edges stay consistent. (file: `libs/frontend_clang/frontend.cpp`) 
- Analyzer: extended exception-boundary detection and matching in `build_function_feature_cache` in `libs/analyzer/analyzer.cpp` to track both per-block boundary ops and exception edges, and only mark `has_unmodeled_exception_flow` when there is a mismatch between edges and boundaries; also treat `landingpad` as a boundary op. (file: `libs/analyzer/analyzer.cpp`) 
- Analyzer: tightened `build_feature_unknown_details` to emit the exception-flow UNKNOWN only when the function both has exception flow and an unmodeled exception-flow mismatch. (file: `libs/analyzer/analyzer.cpp`) 
- Tests: added coverage for the new behaviors: 
  - `tests/analyzer/test_analyzer_unknown_codes.cpp`: added `ExceptionFlowMatchesBoundaryAvoidsUnknown` verifying an `invoke` + exception edge does not produce the conservative exception UNKNOWN. 
  - `tests/analyzer/test_analyzer_points_to.cpp`: added helpers (`make_contract_snapshot_for_target`, `make_nir_with_exception_points_to`, `make_po_list_for_exception_points_to`) and new test `PointsToExceptionPathPropagatesState` to validate points-to effects on an exception path and that a SafetyProof is emitted. 
- Formatting: applied `clang-format` to touched files.

### Testing
- Attempted full configure with Clang frontend ON: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=ON -DSAPPP_WERROR=ON` failed to configure in this environment due to missing system libclang static library (`/usr/lib/llvm-20/lib/libclangBasic.a`) (environment/system mismatch), so frontend-enabled CI couldn't be reproduced here. 
- Reproduced CI with Clang frontend OFF and WERROR enabled: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON` then `cmake --build build --parallel` succeeded. 
- Ran unit tests: `ctest --test-dir build --output-on-failure` and `ctest --test-dir build -R determinism --output-on-failure`; all tests passed (90 tests, 0 failures) after fixing test expectations; determinism subset passed (one EndToEnd determinism test remains skipped in this environment). 
- Ran the added/updated tests individually: `analyzer.AnalyzerUnknownCodeTest.ExceptionFlowMatchesBoundaryAvoidsUnknown` and `analyzer.AnalyzerPointsToTest.PointsToExceptionPathPropagatesState` both passed. 
- Static checks: applied `clang-format` to modified files and ran `clang-tidy`/pre-commit steps via the repository helper; `clang-tidy` completed under the pre-commit workflow (note: running clang-tidy manually earlier produced many warnings when run against the whole tree with strict warnings-as-errors policy in this environment). 
- Pre-commit helper: `./scripts/pre-commit-check.sh` ran but reported two environment-dependent issues: Build (GCC 14) not available here and Schema Validation failed because `ajv-cli` was not installed; these are external to the functional changes. 

Files changed: `libs/frontend_clang/frontend.cpp`, `libs/analyzer/analyzer.cpp`, `tests/analyzer/test_analyzer_points_to.cpp`, `tests/analyzer/test_analyzer_unknown_codes.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a0435c0c832db38aa00f51f932d4)