### PR TITLE
Points-to: model targets as (alloc_site, field), strong-update singletons and summary nodes

### DIFF
--- a/schemas/cert.v1.schema.json
+++ b/schemas/cert.v1.schema.json
@@ -113,8 +113,22 @@
               },
               "targets": {
                 "items": {
-                  "minLength": 1,
-                  "type": "string"
+                  "additionalProperties": false,
+                  "properties": {
+                    "alloc_site": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "field": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "alloc_site",
+                    "field"
+                  ],
+                  "type": "object"
                 },
                 "type": "array"
               }

--- a/tests/analyzer/test_analyzer_points_to.cpp
+++ b/tests/analyzer/test_analyzer_points_to.cpp
@@ -37,13 +37,15 @@ ContractMatchContext make_match_context()
 nlohmann::json make_nir_with_points_to()
 {
     nlohmann::json safe_inst = {
-        {     "id",                                                      "I0"                   },
-        {     "op",                                                                     "assign"},
+        {     "id",                                                    "I0"                   },
+        {     "op",                                                                   "assign"},
         {"effects",
          nlohmann::json{{"points_to",
-         nlohmann::json::array(
-         {nlohmann::json{{"ptr", "p"},
-         {"targets", nlohmann::json::array({"alloc1"})}}})}}                                    }
+         nlohmann::json::array({nlohmann::json{
+         {"ptr", "p"},
+         {"targets",
+         nlohmann::json::array({nlohmann::json{{"alloc_site", "alloc1"},
+         {"field", "root"}}})}}})}}                                                           }
     };
     nlohmann::json safe_anchor_inst = {
         {"id",         "I1"},
@@ -167,13 +169,15 @@ nlohmann::json make_contract_snapshot_for_safe()
 nlohmann::json make_nir_with_exception_points_to()
 {
     nlohmann::json invoke_inst = {
-        {     "id",                                        "I0"                   },
-        {     "op",                                                       "invoke"},
+        {     "id",                                                    "I0"                   },
+        {     "op",                                                                   "invoke"},
         {"effects",
          nlohmann::json{{"points_to",
          nlohmann::json::array({nlohmann::json{
          {"ptr", "p"},
-         {"targets", nlohmann::json::array({"inbounds"})}}})}}                    }
+         {"targets",
+         nlohmann::json::array({nlohmann::json{{"alloc_site", "inbounds"},
+         {"field", "root"}}})}}})}}                                                           }
     };
 
     nlohmann::json exception_block = {
@@ -290,7 +294,8 @@ TEST(AnalyzerPointsToTest, PointsToSimpleResolvesNullDeref)
     EXPECT_EQ(points_to.at(0).at("ptr"), "p");
     const auto& targets = points_to.at(0).at("targets");
     ASSERT_EQ(targets.size(), 1U);
-    EXPECT_EQ(targets.at(0), "alloc1");
+    EXPECT_EQ(targets.at(0).at("alloc_site"), "alloc1");
+    EXPECT_EQ(targets.at(0).at("field"), "root");
 }
 
 TEST(AnalyzerPointsToTest, PointsToExceptionPathPropagatesState)
@@ -342,7 +347,8 @@ TEST(AnalyzerPointsToTest, PointsToExceptionPathPropagatesState)
     EXPECT_EQ(points_to.at(0).at("ptr"), "p");
     const auto& targets = points_to.at(0).at("targets");
     ASSERT_EQ(targets.size(), 1U);
-    EXPECT_EQ(targets.at(0), "inbounds");
+    EXPECT_EQ(targets.at(0).at("alloc_site"), "inbounds");
+    EXPECT_EQ(targets.at(0).at("field"), "root");
 }
 
 }  // namespace sappp::analyzer::test

--- a/tests/analyzer/test_analyzer_unknown_codes.cpp
+++ b/tests/analyzer/test_analyzer_unknown_codes.cpp
@@ -55,7 +55,10 @@ nlohmann::json make_nir_with_ops(const std::vector<std::string_view>& ops,
         if (vcall_config.points_to_ptr.has_value() && inst_index == 0) {
             nlohmann::json targets = nlohmann::json::array();
             for (const auto& target : vcall_config.points_to_targets) {
-                targets.push_back(std::string(target));
+                targets.push_back(nlohmann::json{
+                    {"alloc_site", std::string(target)},
+                    {     "field",              "root"}
+                });
             }
             inst["effects"] = nlohmann::json{
                 {"points_to",

--- a/tests/validator/test_validator.cpp
+++ b/tests/validator/test_validator.cpp
@@ -137,6 +137,7 @@ make_trace_step(const std::string& tu_id,
     return step;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) - Test helper signature is stable.
 [[nodiscard]] nlohmann::json make_bug_trace(const std::string& po_id,
                                             [[maybe_unused]] const std::string& tu_id,
                                             const std::vector<nlohmann::json>& steps)
@@ -912,8 +913,14 @@ TEST(ValidatorTest, DowngradesOnConflictingPointsToState)
     nlohmann::json state = {
         {"predicates",             nlohmann::json::array({predicate_expr})},
         { "points_to",
-         nlohmann::json::array({{{"ptr", "p"}, {"targets", nlohmann::json::array({"alloc1"})}},
-         {{"ptr", "p"}, {"targets", nlohmann::json::array({"alloc2"})}}}) }
+         nlohmann::json::array({{{"ptr", "p"},
+         {"targets",
+         nlohmann::json::array({nlohmann::json{{"alloc_site", "alloc1"},
+         {"field", "root"}}})}},
+         {{"ptr", "p"},
+         {"targets",
+         nlohmann::json::array({nlohmann::json{{"alloc_site", "alloc2"},
+         {"field", "root"}}})}}})                                         }
     };
     nlohmann::json safety_proof =
         make_safety_proof(state, "interval+null+lifetime+init+points-to.simple");


### PR DESCRIPTION
### Motivation

- Improve precision of points-to modeling by representing targets as (alloc_site, field) pairs instead of plain strings, enabling field-aware updates and merging. 
- Support NIR-produced richer points-to targets (either legacy string root targets or new object form) and avoid exploding target sets by summarizing when exceeding `kMaxPointsToTargets`.

### Description

- Reworked the analyzer points-to representation from `std::vector<std::string>` to `std::vector<PointsToTarget>` where `PointsToTarget` = `{alloc_site, field}` and added ordering, equality, and helper predicates. (file: `libs/analyzer/analyzer.cpp`) 
- Accepted both legacy string targets and the new structured target objects (`{"alloc_site","field"}`) in `extract_points_to_effects`; string form maps to `field ==

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69782322a114832d82825a6d3812f61e)