### PR TITLE
Resolve vcall candidates using points-to dynamic types and SpecDB vtable info; stabilize ordering

### DIFF
--- a/libs/validator/validator.cpp
+++ b/libs/validator/validator.cpp
@@ -754,9 +754,10 @@ validate_trace_transition(const TraceStepInfo& previous,
             return proof_failed_error("BugTrace unwind without call frame");
         }
         auto reversed_call_stack = call_stack | std::views::reverse;
-        auto match_it = std::ranges::find_if(reversed_call_stack, [&](const CallFrame& frame) {
-            return frame.function_uid == current.function_uid;
-        });
+        auto match_it =
+            std::ranges::find_if(reversed_call_stack, [&](const CallFrame& frame) noexcept {
+                return frame.function_uid == current.function_uid;
+            });
         if (match_it == std::ranges::end(reversed_call_stack)) {
             return proof_failed_error("BugTrace unwind target mismatch");
         }


### PR DESCRIPTION
### Motivation

- Improve virtual-call resolution by extracting dynamic-type candidates from points-to results to avoid spurious `VirtualDispatchUnknown` outcomes. 
- Use available type hierarchy / vtable information in `nir` and optional `specdb_snapshot` to map runtime types to vtable methods. 
- Ensure candidate sets and unknown IDs are stable and deterministic across different `--jobs` settings. 

### Description

- Added type-hierarchy and vtable support: introduced `VCallTypeInfo`, `VCallTypeHierarchy` and helper APIs (`extract_string_array`, `extract_vtable_methods`, `merge_type_entry`, `merge_type_hierarchy_from_json`, `build_vcall_type_hierarchy`, `resolve_points_to_type_id`, `collect_vtable_methods_for_type`, `collect_vcall_methods_from_points_to_targets`) to build/consume type & vtable info from `nir` and `specdb_snapshot`.
- Extended vcall summarization to capture `receiver_keys` in `VCallSummary` and to expose a `vcall_type_hierarchy` pointer in `PoProcessingContext`; `analyze()` now builds the type hierarchy from `nir` and `specdb_snapshot` and passes it into the processing context.
- Enhanced `resolve_vcall_candidates_for_po()` to: (1) prefer candidate set from anchor when available, (2) fall back to a single `receiver_key` when the candidate anchor is missing, (3) consult points-to targets and map them through the type hierarchy to vtable methods before filtering the candidate set, and (4) stable-sort + unique the resulting candidate list to maintain determinism.
- Avoided emitting `VirtualDispatchUnknown` when points-to + type/vtable lookup narrows the candidate set to concrete targets; kept legacy unknown reasons for truly-empty/absent candidate sets.
- Added unit-level support in tests: updated `tests/analyzer/test_analyzer_unknown_codes.cpp` with `make_type_entry()` and a new test `NumericUnknownWithVcallDynamicTypeResolved` that exercises dynamic-type → vtable resolution; made various defensive/init fixes (default ctors for POD-like structs, `noexcept` on small lambdas) to satisfy project warnings-as-errors policy.

### Testing

- Performed an in-source CI reproduction: configured and built with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DSAPPP_BUILD_TESTS=ON -DSAPPP_BUILD_CLANG_FRONTEND=OFF -DSAPPP_WERROR=ON` and `cmake --build build --parallel`, which completed successfully.
- Ran the full test-suite with `ctest --test-dir build --output-on-failure` and determinism subset `ctest --test-dir build -R determinism --output-on-failure`; all automated tests passed (overall tests: 93/93 passed; determinism tests: 30/30 passed).
- Executed project quality checks including `clang-format`, `clang-tidy`, and the project pre-commit script `./scripts/pre-commit-check.sh`; the checks completed and the build+tests reported success in the local CI reproduction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697823263224832d9623d1098bd56079)